### PR TITLE
Add Complete functionalities of two endpoints(/news, /news_keywords).

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ In addition, to keep the knowledge base of news up to date, a scheduled script w
 
 <img width="984" alt="image" src="https://github.com/CoToYo/b0bot/assets/56789038/4e5fe460-a210-46e9-b490-caa02e34c3af">
 
-B0Bot API will continuely run as a serverless function (hosted on [Render](https://render.com/)) and it will record a successfull operation in a monitoring dashboard set up in [Better Uptime](https://betterstack.com/better-uptime).
+The API will continuely run as a serverless function (hosted on [Render](https://render.com/)) and it will record a successfull operation in a monitoring dashboard set up in [Better Uptime](https://betterstack.com/better-uptime).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# B0Bot API - Bug Zero Bot API
+# B0Bot - CyberSecurity News API
 
-B0Bot API is a Flask API that provides recent hacker, cybersecurity news. Users can request the API with or without keywords and get news easily.
+In this project, our objective is to develop a CyberSecurity News API tailored for automated bots on social media platforms.
+
+It is a cutting-edge Flask-based API that grants seamless access to the latest cybersecurity and hacker news. Users can effortlessly retrieve news articles either through specific keywords or without, streamlining the information acquisition process.
+
+Once a user requests our API, it retrieves news data from our knowledge base and feeds it to ChatGPT. After ChatGPT processes the data, the API obtains the response and returns it in JSON format.
 
 # High-Level Architecture Diagram
 
-B0Bot API lives inside a Flask API and is powered by LangChain and OpenAI API. 
+Our API lives inside a Flask API and is powered by LangChain and OpenAI API. 
 
-In addition, to keep the knowledge base of news up to date, a scheduled script will be executed on a regular interval to retrieve the most recent cybersecurity news by scraping a list of target news websites and store them into the MongoDB Atlas Database. Everytime a user requests the B0Bot API, news in the database will be read into LangChain's memory and fed to the LLM of OpenAI. Then, answers will be generated based on both OpenAI model and our knowledge base.
+In addition, to keep the knowledge base of news up to date, a scheduled script will be executed on a regular interval to retrieve the most recent cybersecurity news by scraping a list of target news websites and store them into the MongoDB Atlas Database. Everytime a user requests the API, news in the database will be read into LangChain's memory and fed to the LLM of OpenAI. Then, answers will be generated based on both OpenAI model and our knowledge base.
 
 <img width="908" alt="image" src="https://github.com/CoToYo/b0bot/assets/56789038/218fdf2b-be27-4222-9119-81c3dc5c4e02">
 

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ app.register_blueprint(routes)
 
 
 if __name__ == "__main__":
+    # app.run(debug=True, host="0.0.0.0")
     app.run()
 
 #     news_list = data.split("\n")

--- a/controllers/NewsController.py
+++ b/controllers/NewsController.py
@@ -1,27 +1,27 @@
-import services.NewsService as NewsService
-
-"""
-return news without considering keywords
-"""
+from services.NewsService import NewsService
 
 
-def getNews():
-    return NewsService.getNews()
+class NewsController:
+    def __init__(self) -> None:
+        self.news_service = NewsService()
 
+    """
+    return news without considering keywords
+    """
 
-"""
-return news based on certain keywords
-"""
+    def getNews(self):
+        return self.news_service.getNews()
 
+    """
+    return news based on certain keywords
+    """
 
-def getNewsWithKeywords(user_keywords):
-    return NewsService.getNewsWithKeywords(user_keywords)
+    def getNewsWithKeywords(self, user_keywords):
+        return self.news_service.getNewsWithKeywords(user_keywords)
 
+    """
+    deal requests with wrong route
+    """
 
-"""
-deal requests with wrong route
-"""
-
-
-def notFound(error):
-    return NewsService.notFound(error)
+    def notFound(self, error):
+        return self.news_service.notFound(error)

--- a/db_update/Update.py
+++ b/db_update/Update.py
@@ -52,7 +52,7 @@ news = {
 Notice: "id" should be removed before the news is inserted into the database.
 """
 
-# db has limited storage space(512mb), clean up the old news everytime
+# db has limited storage space(512mb), clean up old news before fetching new news.
 collection.delete_many({})
 
 # Insert all feteched news into the database.

--- a/models/NewsModel.py
+++ b/models/NewsModel.py
@@ -1,7 +1,14 @@
 from config.Database import client
 
-db = client.CybernewsDB
-
 """
 TODO: Read news from database.
 """
+
+
+class CybernewsDB:
+    def __init__(self):
+        self.client = client
+        self.db = self.client["CybernewsDB"]
+
+    def get_collections(self, collection_name):
+        return self.db.get_collection(collection_name)

--- a/models/NewsModel.py
+++ b/models/NewsModel.py
@@ -1,14 +1,10 @@
 from config.Database import client
 
-"""
-TODO: Read news from database.
-"""
-
 
 class CybernewsDB:
     def __init__(self):
         self.client = client
         self.db = self.client["CybernewsDB"]
 
-    def get_collections(self, collection_name):
-        return self.db.get_collection(collection_name)
+    def get_news_collections(self):
+        return self.db.get_collection("news")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-python-dotenv
-Flask
-langchain==0.0.222
-openai
+python-dotenv==1.0.0
+Flask==2.3.2
+langchain==0.0.256
+openai==0.27.8
 gunicorn==19.7.1
 pymongo==4.4.0
 dnspython==2.3.0
-cybernews
+cybernews==1.1.2
+pydantic==1.10.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv
 Flask
-langchain==0.0.24
+langchain
 openai==0.27.8
 gunicorn==19.7.1
 pymongo==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dotenv
-Flask==2.3.2
+Flask
 langchain==0.0.256
 openai==0.27.8
 gunicorn==19.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python-dotenv
 Flask
 langchain
 openai==0.27.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-dotenv
 Flask
 langchain
 openai==0.27.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv
 Flask
-langchain
+langchain==0.0.222
 openai
 gunicorn==19.7.1
 pymongo==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-dotenv==1.0.0
+python-dotenv
 Flask==2.3.2
 langchain==0.0.256
 openai==0.27.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv
 Flask
-langchain==0.0.25
+langchain==0.0.22
 openai==0.27.8
 gunicorn==19.7.1
 pymongo==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv
 Flask
-langchain==0.0.22
+langchain==0.0.24
 openai==0.27.8
 gunicorn==19.7.1
 pymongo==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 python-dotenv
 Flask
-langchain==0.0.256
+langchain==0.0.25
 openai==0.27.8
 gunicorn==19.7.1
 pymongo==4.4.0
 dnspython==2.3.0
-cybernews==1.1.2
-pydantic==1.10.9
+cybernews

--- a/routes/NewsRoutes.py
+++ b/routes/NewsRoutes.py
@@ -1,7 +1,8 @@
 from flask import *
-from controllers.NewsController import *
+from controllers.NewsController import NewsController
 
 routes = Blueprint("routes", __name__)
+news_controller = NewsController()
 
 """
 return news without considering keywords
@@ -10,7 +11,7 @@ return news without considering keywords
 
 @routes.route("/news", methods=["GET"])
 def getNews_route():
-    return getNews()
+    return news_controller.getNews()
 
 
 """
@@ -22,7 +23,7 @@ return news based on certain keywords
 def getNewsWithKeywords_route():
     # get list of keywords as argument from User's request
     user_keywords = request.args.getlist("keywords")
-    return getNewsWithKeywords(user_keywords)
+    return news_controller.getNewsWithKeywords(user_keywords)
 
 
 """
@@ -32,4 +33,4 @@ deal requests with wrong route
 
 @routes.errorhandler(404)
 def notFound_route(error):
-    notFound(error)
+    news_controller.notFound(error)

--- a/services/NewsService.py
+++ b/services/NewsService.py
@@ -1,39 +1,71 @@
 from dotenv import dotenv_values
 from flask import jsonify
+
+# import json
 from langchain.llms import OpenAI
 from langchain.chat_models import ChatOpenAI
 from langchain.prompts import PromptTemplate
+from langchain.schema import HumanMessage, SystemMessage, AIMessage
+from langchain.chains import LLMChain, SimpleSequentialChain
 from models.NewsModel import CybernewsDB
 
 
 class NewsService:
     def __init__(self) -> None:
-        self.OPENAI_API_KEY = dotenv_values(".env").get("OPENAI_API_KEY")
-        self.llm = OpenAI(temperature=0.9, openai_api_key=self.OPENAI_API_KEY)
         self.db = CybernewsDB()
+        self.OPENAI_API_KEY = dotenv_values(".env").get("OPENAI_API_KEY")
+        self.llm = ChatOpenAI(temperature=0.1, openai_api_key=self.OPENAI_API_KEY)
+        # fixed format for answer
+        self.news_format = "title [source, date(MM/DD/YYYY), news url];"
+        self.news_number = 10
 
     """
     Return news without considering keywords
     """
 
     def getNews(self):
-        # fixed format for answer
-        answer_format = "news content (data source, date)"
-
-        # add prompt
-        prompt = PromptTemplate(
-            input_variables=["format"],
-            template="""
-            Please give me a list of the most recent cybersecurity news.
-            Indicate data source and date.
-            Return the answer with the format of '{format}'.
-            """,
+        # fetch news data from db:
+        # only fetch data with valid `author` and `newsDate`
+        # drop field "id" from collection
+        news_data = self.db.get_news_collections().find(
+            {"author": {"$ne": "N/A"}, "newsDate": {"$ne": "N/A"}},
+            {
+                "headlines": 1,
+                "newsDate": 1,
+                "author": 1,
+                "newsURL": 1,
+                "_id": 0,
+            },
         )
-        news = self.llm(prompt.format(format=answer_format))
-        print(news)
+        news_data = list(news_data)
+
+        news = self.llm(
+            [
+                SystemMessage(
+                    content="You are a news analyzer that will read the given cyber security news and return the answer based on the user's requirement."
+                ),
+                HumanMessage(content=str(news_data)),
+                AIMessage(
+                    content="I have read the news you provided. Now please tell me your request."
+                ),
+                HumanMessage(
+                    content="""Please give me a list of the most recent cybersecurity news based on the news given above.
+                    Indicate the source and date.
+                    Each news should be strictly in the format of {news_format}.
+                    Your reply should be news-only, without adding any of your conversational content.
+                    Do not use bullet points.
+                    Do not stop generating the answer until it is complete.
+                    Return at most {news_number} news.""".format(
+                        news_format=self.news_format, news_number=self.news_number
+                    )
+                ),
+            ]
+        )
+
+        print(news.content)
 
         # convert news data into JSON format
-        news_JSON = self.toJSON(news)
+        news_JSON = self.toJSON(news.content)
 
         return news_JSON
 
@@ -42,23 +74,53 @@ class NewsService:
     """
 
     def getNewsWithKeywords(self, user_keywords):
-        # fixed format for answer
-        answer_format = "news content (data source, date)"
-
-        # add prompt
-        prompt = PromptTemplate(
-            input_variables=["keywords", "format"],
-            template="""
-            Please give me a list of the most recent cybersecurity news with keywords of {keywords}.
-            Indicate data source and date.
-            Return the answer with the format of '{format}'.
-            """,
+        # fetch news data from db:
+        # only fetch data with valid `author` and `newsDate`
+        # drop field "id" from collection
+        news_data = self.db.get_news_collections().find(
+            {"author": {"$ne": "N/A"}, "newsDate": {"$ne": "N/A"}},
+            {
+                "headlines": 1,
+                "newsDate": 1,
+                "author": 1,
+                "newsURL": 1,
+                "_id": 0,
+            },
         )
-        news = self.llm(prompt.format(keywords=user_keywords, format=answer_format))
-        print(news)
+        news_data = list(news_data)
+
+        news = self.llm(
+            [
+                SystemMessage(
+                    content="You are a news analyzer that will read the given cyber security news and return the answer based on the user's requirement."
+                ),
+                HumanMessage(content=str(news_data)),
+                AIMessage(
+                    content="OK. I have read the news you provided. Now please give me your keywords."
+                ),
+                HumanMessage(content=str(user_keywords)),
+                AIMessage(
+                    content="OK. I have read the keywords you provided. Now please tell me how you want me to generate the answers."
+                ),
+                HumanMessage(
+                    content="""Please give me the most recent cybersecurity news related to the keywords based on the news I provided.
+                    Indicate the source and date;
+                    Each news should be strictly in the format of {news_format}.
+                    Your reply should be news-only, without adding any of your conversational content.
+                    Do not use bullet points.
+                    Do not stop generating the answer until it is complete.
+                    Return at most {news_number} news.
+                    Return nothing if there is no news related to the keywords.""".format(
+                        news_format=self.news_format, news_number=self.news_number
+                    )
+                ),
+            ]
+        )
+
+        print(news.content)
 
         # convert news data into JSON format
-        news_JSON = self.toJSON(news)
+        news_JSON = self.toJSON(news.content)
 
         return news_JSON
 
@@ -74,6 +136,8 @@ class NewsService:
     """
 
     def toJSON(self, data: str):
+        if len(data) == 0:
+            return {}
         news_list = data.split("\n")
         news_list_json = []
 
@@ -82,16 +146,23 @@ class NewsService:
             if len(item) == 0:
                 continue
             # Split the string at the first occurrence of '('
-            title, remaining = item.split("(", 1)
+            title, remaining = item.split("[", 1)
+            title = title.strip(' "')
 
             # Extract the source by splitting at ',' and removing leading/trailing whitespace
-            source = remaining.split(",")[0].strip()
+            source, date, url = remaining.split(",")
 
-            # Extract the date by splitting at ',' and removing leading/trailing whitespace
-            date = remaining.split(",")[1].strip().rstrip(")")
+            source = source.strip(' "')
+            date = date.strip(' "')
+            url = url.strip(" ];")
 
             # Create a dictionary for each news item and append it to the news_list
-            news_item = {"title": title.strip(), "source": source, "date": date}
+            news_item = {
+                "title": title,
+                "source": source,
+                "date": date,
+                "url": url,
+            }
             news_list_json.append(news_item)
 
         return jsonify(news_list_json)

--- a/services/NewsService.py
+++ b/services/NewsService.py
@@ -3,100 +3,95 @@ from flask import jsonify
 from langchain.llms import OpenAI
 from langchain.chat_models import ChatOpenAI
 from langchain.prompts import PromptTemplate
-
-"""
-Create a LLM object
-"""
-OPENAI_API_KEY = dotenv_values(".env").get("OPENAI_API_KEY")
-llm = OpenAI(temperature=0.9, openai_api_key=OPENAI_API_KEY)
-
-"""
-Return news without considering keywords
-"""
+from models.NewsModel import CybernewsDB
 
 
-def getNews():
-    # fixed format for answer
-    answer_format = "news content (data source, date)"
+class NewsService:
+    def __init__(self) -> None:
+        self.OPENAI_API_KEY = dotenv_values(".env").get("OPENAI_API_KEY")
+        self.llm = OpenAI(temperature=0.9, openai_api_key=self.OPENAI_API_KEY)
+        self.db = CybernewsDB()
 
-    # add prompt
-    prompt = PromptTemplate(
-        input_variables=["format"],
-        template="""
-        Please give me a list of the most recent cybersecurity news.
-        Indicate data source and date.
-        Return the answer with the format of '{format}'.
-        """,
-    )
-    news = llm(prompt.format(format=answer_format))
-    print(news)
+    """
+    Return news without considering keywords
+    """
 
-    # convert news data into JSON format
-    news_JSON = toJSON(news)
+    def getNews(self):
+        # fixed format for answer
+        answer_format = "news content (data source, date)"
 
-    return news_JSON
+        # add prompt
+        prompt = PromptTemplate(
+            input_variables=["format"],
+            template="""
+            Please give me a list of the most recent cybersecurity news.
+            Indicate data source and date.
+            Return the answer with the format of '{format}'.
+            """,
+        )
+        news = self.llm(prompt.format(format=answer_format))
+        print(news)
 
+        # convert news data into JSON format
+        news_JSON = self.toJSON(news)
 
-"""
-return news based on certain keywords
-"""
+        return news_JSON
 
+    """
+    return news based on certain keywords
+    """
 
-def getNewsWithKeywords(user_keywords):
-    # fixed format for answer
-    answer_format = "news content (data source, date)"
+    def getNewsWithKeywords(self, user_keywords):
+        # fixed format for answer
+        answer_format = "news content (data source, date)"
 
-    # add prompt
-    prompt = PromptTemplate(
-        input_variables=["keywords", "format"],
-        template="""
-        Please give me a list of the most recent cybersecurity news with keywords of {keywords}.
-        Indicate data source and date.
-        Return the answer with the format of '{format}'.
-        """,
-    )
-    news = llm(prompt.format(keywords=user_keywords, format=answer_format))
-    print(news)
+        # add prompt
+        prompt = PromptTemplate(
+            input_variables=["keywords", "format"],
+            template="""
+            Please give me a list of the most recent cybersecurity news with keywords of {keywords}.
+            Indicate data source and date.
+            Return the answer with the format of '{format}'.
+            """,
+        )
+        news = self.llm(prompt.format(keywords=user_keywords, format=answer_format))
+        print(news)
 
-    # convert news data into JSON format
-    news_JSON = toJSON(news)
+        # convert news data into JSON format
+        news_JSON = self.toJSON(news)
 
-    return news_JSON
+        return news_JSON
 
+    """
+    deal requests with wrong route
+    """
 
-"""
-deal requests with wrong route
-"""
+    def notFound(self, error):
+        return jsonify({"error": error}), 404
 
+    """
+    Convert news given by OpenAI API into JSON format.
+    """
 
-def notFound(error):
-    return jsonify({"error": "Not Found"}), 404
+    def toJSON(self, data: str):
+        news_list = data.split("\n")
+        news_list_json = []
 
+        for item in news_list:
+            # Avoid dirty data
+            if len(item) == 0:
+                continue
+            # Split the string at the first occurrence of '('
+            title, remaining = item.split("(", 1)
 
-"""
-Convert news given by OpenAI API into JSON format.
-"""
+            # Extract the source by splitting at ',' and removing leading/trailing whitespace
+            source = remaining.split(",")[0].strip()
 
+            # Extract the date by splitting at ',' and removing leading/trailing whitespace
+            date = remaining.split(",")[1].strip().rstrip(")")
 
-def toJSON(data: str):
-    news_list = data.split("\n")
-    news_list_json = []
+            # Create a dictionary for each news item and append it to the news_list
+            news_item = {"title": title.strip(), "source": source, "date": date}
+            news_list_json.append(news_item)
 
-    for item in news_list:
-        # Avoid dirty data
-        if len(item) == 0:
-            continue
-        # Split the string at the first occurrence of '('
-        title, remaining = item.split("(", 1)
-
-        # Extract the source by splitting at ',' and removing leading/trailing whitespace
-        source = remaining.split(",")[0].strip()
-
-        # Extract the date by splitting at ',' and removing leading/trailing whitespace
-        date = remaining.split(",")[1].strip().rstrip(")")
-
-        # Create a dictionary for each news item and append it to the news_list
-        news_item = {"title": title.strip(), "source": source, "date": date}
-        news_list_json.append(news_item)
-
-    return jsonify(news_list_json)
+        return jsonify(news_list_json)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Now, our API will fetch news data from our knowledge base and feed to the OpenAI LLM every time a user requesting.
This improvement empower our API to provide users with most recent cyber news.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before this change was made, our API retrieve cyber news directly from OpenAI LLM, where only has outdated data. With this change being made, news return by our API are up to date.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Have using postman to test for 60+ times and all results were good.
- Postman:
`\news`
![image](https://github.com/c2siorg/b0bot/assets/56789038/61ba34fb-901b-4972-ad18-246549cba498)

`\news_keywords`
![image](https://github.com/c2siorg/b0bot/assets/56789038/5f65a433-77a0-42c2-8ed5-d2e07a7ae8e2)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
