### PR TITLE
 Updated Pinecone Index Name in README.md to "cybernews-index"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once a user requests our API, it retrieves news data from our knowledge base and
 ```
 https://www.pinecone.io/
 ```
-Login to Pinecone and create a new index with the name `news-index`. Then, add the Pinecone API key in the `.env` file.
+Login to Pinecone and create a new index with the name `cybernews-index`. Then, add the Pinecone API key in the `.env` file.
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,10 @@ pymongo==4.4.0
 dnspython==2.3.0
 huggingface_hub
 beautifulsoup4==4.11.2
-lxml==4.9.2
+lxml==5.3.0
 httpx==0.23.3
 requests==2.28.2
 pinecone-client
 langchain-pinecone
 sentence-transformers
+langchain-community


### PR DESCRIPTION
This PR updates the Pinecone index name  from "news-index" which is originally mentioned in README.md to "cybernews-index" to reflect the actual name of the index.

Changes Made:

The line `Login to Pinecone and create a new index with the name news-index. Then, add the Pinecone API key in the .env file.`
changes to 

`Login to Pinecone and create a new index with the name cybernews-index. Then, add the Pinecone API key in the .env file.`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
