### PR TITLE
fix(api-service): make chat-based subscribe actually create a subscriber row

### DIFF
--- a/api-service/agents/notification.py
+++ b/api-service/agents/notification.py
@@ -1,56 +1,87 @@
 import re
-import json
-import hashlib
-import os
-import redis
 from agents.state import PlannerState
+from models.SubscriberModel import SubscriberDB
 
-REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-DIGEST_QUEUE = "digest-jobs"
+KNOWN_INTEREST_TAGS = {"malware", "ransomware", "cve", "data breach", "vulnerability"}
+EVERYTHING_PHRASES = {"everything", "all articles", "all news", "anything", "all topics"}
 
-try:
-    redis_client = redis.from_url(REDIS_URL, decode_responses=True)
-except Exception:
-    redis_client = None
+db = SubscriberDB()
+
 
 def _extract_email(text: str) -> str:
     match = re.search(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", text)
     return match.group(0) if match else ""
+
 
 def _extract_frequency(text: str) -> str:
     if "weekly" in text.lower():
         return "weekly"
     return "daily"
 
+
+def _extract_known_interests(text: str) -> list[str]:
+    lowered = text.lower()
+    return [tag for tag in KNOWN_INTEREST_TAGS if tag in lowered]
+
+
+def _wants_everything(text: str) -> bool:
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in EVERYTHING_PHRASES)
+
+
+def _gather_subscribe_context(state: PlannerState) -> str:
+    """Combine the current message with any prior turns that were also
+    part of this subscribe flow, so a multi-turn clarification (email in
+    one message, topics in the next) still has full context. Stops at the
+    first prior turn that wasn't subscribe intent, so unrelated earlier
+    messages never leak into this.
+    """
+    history = state.get("chat_history") or []
+    parts = []
+    for entry in reversed(history):
+        if entry.get("role") != "user":
+            continue
+        if entry.get("intent") != "subscribe":
+            break
+        parts.append(entry.get("content", ""))
+    parts.reverse()
+    parts.append(state.get("user_input", ""))
+    return " ".join(parts)
+
+
 def notification_agent(state: PlannerState) -> PlannerState:
-    user_input = state.get("user_input", "")
-    keywords = state.get("keywords", [])
+    combined = _gather_subscribe_context(state)
 
-    email = _extract_email(user_input)
-    frequency = _extract_frequency(user_input)
-    # keywords from PlannerAgent become the subscriber's interest tags
-    interests = [k for k in keywords if k not in {"subscribe", "notify", "alert", "digest", "to", "for", "me", "daily", "weekly"}]
+    email = _extract_email(combined)
+    if not email:
+        return {
+            **state,
+            "notification_triggered": False,
+            "notification_message": "what email should I use for the subscription?",
+        }
 
-    payload = {
-        "email": email,
-        "frequency": frequency,
-        "interests": interests,
+    frequency = _extract_frequency(combined)
+    interests = _extract_known_interests(combined)
+    everything = _wants_everything(combined)
+
+    if not interests and not everything:
+        options = ", ".join(sorted(KNOWN_INTEREST_TAGS))
+        return {
+            **state,
+            "notification_triggered": False,
+            "notification_message": f"which topics are you interested in? options are {options}, or say everything for all articles",
+        }
+
+    db.create_subscriber(email=email, frequency=frequency, interests=interests)
+
+    if interests:
+        topics_text = ", ".join(sorted(interests))
+        confirm = f"subscribed, you'll get {frequency} digests for {topics_text}"
+    else:
+        confirm = f"subscribed, you'll get {frequency} digests with all articles"
+
+    return {
+        **state,
+        "notification_triggered": True,
+        "notification_message": confirm,
     }
-
-    idempotency_key = "digest:" + hashlib.md5(
-        f"{email}:{frequency}".encode()
-    ).hexdigest()
-
-    job = {
-        "event_type": "article.digest",
-        "idempotency_key": idempotency_key,
-        "payload": payload,
-    }
-
-    if redis_client:
-        try:
-            redis_client.lpush(DIGEST_QUEUE, json.dumps(job))
-        except Exception:
-            pass
-
-    return {**state, "notification_triggered": True}

--- a/api-service/agents/notification.py
+++ b/api-service/agents/notification.py
@@ -12,7 +12,7 @@ db = SubscriberDB()
 
 
 def _extract_email(text: str) -> str:
-    match = re.search(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", text)
+    match = re.search(r"(?<![\w.])[a-zA-Z0-9_%+-]+(?:\.[a-zA-Z0-9_%+-]+)*@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}(?![\w.])", text)
     return match.group(0) if match else ""
 
 
@@ -87,7 +87,13 @@ def notification_agent(state: PlannerState) -> PlannerState:
             "notification_message": f"which topics are you interested in? options are {options}, or say everything for all articles",
         }
 
-    db.create_subscriber(email=email, frequency=frequency, interests=interests)
+    created = db.create_subscriber(email=email, frequency=frequency, interests=interests)
+    if not created:
+        return {
+            **state,
+            "notification_triggered": False,
+            "notification_message": "something went wrong saving your subscription, can you try again in a bit?",
+        }
 
     if interests:
         topics_text = ", ".join(sorted(interests))

--- a/api-service/agents/notification.py
+++ b/api-service/agents/notification.py
@@ -16,9 +16,15 @@ def _extract_email(text: str) -> str:
     return match.group(0) if match else ""
 
 
-def _extract_frequency(text: str) -> str:
-    if "weekly" in text.lower():
+UNSUPPORTED_FREQUENCY_TERMS = {"hourly", "monthly", "biweekly", "quarterly", "real-time", "instant", "every hour", "every 12 hours"}
+
+
+def _extract_frequency(text: str) -> str | None:
+    lowered = text.lower()
+    if "weekly" in lowered:
         return "weekly"
+    if any(term in lowered for term in UNSUPPORTED_FREQUENCY_TERMS):
+        return None
     return "daily"
 
 
@@ -64,6 +70,12 @@ def notification_agent(state: PlannerState) -> PlannerState:
         }
 
     frequency = _extract_frequency(combined)
+    if frequency is None:
+        return {
+            **state,
+            "notification_triggered": False,
+            "notification_message": "only daily or weekly digests are supported right now, which one do you want?",
+        }
     interests = _extract_known_interests(combined)
     everything = _wants_everything(combined)
 

--- a/api-service/agents/notification.py
+++ b/api-service/agents/notification.py
@@ -2,7 +2,10 @@ import re
 from agents.state import PlannerState
 from models.SubscriberModel import SubscriberDB
 
-KNOWN_INTEREST_TAGS = {"malware", "ransomware", "cve", "data breach", "vulnerability"}
+KNOWN_INTEREST_TAGS = {
+    "malware", "ransomware", "cve", "data breach", "vulnerability",
+    "phishing", "zero-day", "data leak", "supply chain", "insider threat",
+}
 EVERYTHING_PHRASES = {"everything", "all articles", "all news", "anything", "all topics"}
 
 db = SubscriberDB()
@@ -21,7 +24,7 @@ def _extract_frequency(text: str) -> str:
 
 def _extract_known_interests(text: str) -> list[str]:
     lowered = text.lower()
-    return [tag for tag in KNOWN_INTEREST_TAGS if tag in lowered]
+    return [tag for tag in sorted(KNOWN_INTEREST_TAGS) if tag in lowered]
 
 
 def _wants_everything(text: str) -> bool:

--- a/api-service/agents/responder.py
+++ b/api-service/agents/responder.py
@@ -23,7 +23,8 @@ def responder_agent(state: PlannerState) -> PlannerState:
     intent = state.get("intent", "search")
 
     if intent == "subscribe":
-        response = {"message": "Subscribed successfully. You will receive digests based on your interests.", "articles": []}
+        message = state.get("notification_message") or "Subscribed successfully."
+        response = {"message": message, "articles": []}
         return {**state, "llm_response": json.dumps(response)}
 
     cache_key = _cache_key(user_input, intent)

--- a/api-service/agents/state.py
+++ b/api-service/agents/state.py
@@ -9,4 +9,5 @@ class PlannerState(TypedDict):
     session_id: Optional[str]
     chat_history: Optional[List[dict]]
     notification_triggered: bool
+    notification_message: Optional[str]
     analysis: Optional[Any]

--- a/api-service/models/SubscriberModel.py
+++ b/api-service/models/SubscriberModel.py
@@ -1,0 +1,54 @@
+"""Postgres-backed subscriber store.
+
+Handles creating and updating subscriber records for the email digest.
+Used by both the /subscribe route and NotificationAgent's chat-based
+subscribe flow, so there's exactly one place that writes to subscribers
+and subscriber_interests, regardless of how someone subscribed.
+"""
+import logging
+
+from config.Database import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+class SubscriberDB:
+    def create_subscriber(self, email: str, frequency: str = "daily", interests: list[str] | None = None) -> bool:
+        """Insert or reactivate a subscriber and their interest tags.
+
+        Existing subscribers (matched by email) are reactivated and have
+        their frequency updated rather than duplicated. Returns False (and
+        logs) if the database is unreachable or the insert fails.
+        """
+        interests = interests or []
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO subscribers (email, digest_frequency, status)
+                    VALUES (%(email)s, %(frequency)s, 'active')
+                    ON CONFLICT (email) DO UPDATE SET
+                        digest_frequency = EXCLUDED.digest_frequency,
+                        status = 'active',
+                        updated_at = NOW()
+                    RETURNING id
+                    """,
+                    {"email": email, "frequency": frequency},
+                )
+                subscriber_id = cur.fetchone()["id"]
+
+                for tag in interests:
+                    cur.execute(
+                        """
+                        INSERT INTO subscriber_interests (subscriber_id, tag)
+                        VALUES (%(subscriber_id)s, %(tag)s)
+                        ON CONFLICT DO NOTHING
+                        """,
+                        {"subscriber_id": subscriber_id, "tag": tag},
+                    )
+
+                conn.commit()
+                return True
+        except Exception as exc:
+            logger.error("Failed to create subscriber: %s", exc)
+            return False

--- a/api-service/routes/NewsRoutes.py
+++ b/api-service/routes/NewsRoutes.py
@@ -150,7 +150,7 @@ def chat_route():
 
     response = result["llm_response"]
 
-    history.append({"role": "user", "content": user_input})
+    history.append({"role": "user", "content": user_input, "intent": result.get("intent")})
     history.append({"role": "assistant", "content": response})
     _save_history(session_id, history[-MAX_HISTORY:])
 

--- a/api-service/tests/test_graph_routing.py
+++ b/api-service/tests/test_graph_routing.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import MagicMock
 
 
@@ -29,12 +28,14 @@ class TestGraphRouting:
         from agents import responder as responder_module
         mock_db = MagicMock()
         mocker.patch.object(scraper_module, "db", mock_db)
+        mock_subscriber_db = MagicMock()
+        mock_subscriber_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_subscriber_db)
         mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
         mocker.patch.object(responder_module, "redis_client", mock_redis)
         from agents import agent_graph
         result = agent_graph.invoke({
-            "user_input": "subscribe vishak@example.com daily",
+            "user_input": "subscribe vishak@example.com daily to ransomware alerts",
             "session_id": "test",
             "chat_history": [],
             "notification_triggered": False,

--- a/api-service/tests/test_notification.py
+++ b/api-service/tests/test_notification.py
@@ -1,5 +1,3 @@
-import json
-import pytest
 from unittest.mock import MagicMock
 
 
@@ -13,6 +11,7 @@ def make_state(**kwargs):
         "session_id": "test-session",
         "chat_history": [],
         "notification_triggered": False,
+        "notification_message": None,
         "analysis": None,
     }
     base.update(kwargs)
@@ -20,50 +19,74 @@ def make_state(**kwargs):
 
 
 class TestNotificationAgent:
-    def test_email_extracted(self, mocker):
-        from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
+    def test_asks_for_email_when_missing(self, mocker):
         from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com daily", keywords=["vishak@example.com", "daily"])
-        notification_agent(state)
-        job = json.loads(mock_redis.lpush.call_args[0][1])
-        assert job["payload"]["email"] == "vishak@example.com"
+        state = make_state(user_input="subscribe me to malware alerts daily")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "email" in result["notification_message"].lower()
 
-    def test_weekly_frequency_extracted(self, mocker):
-        from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
+    def test_asks_for_interests_when_no_known_tag_matched(self, mocker):
         from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com weekly", keywords=[])
-        notification_agent(state)
-        job = json.loads(mock_redis.lpush.call_args[0][1])
-        assert job["payload"]["frequency"] == "weekly"
+        state = make_state(user_input="subscribe vishak@example.com to cybersecurity news")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "topics" in result["notification_message"].lower()
+
+    def test_everything_is_a_valid_choice(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to everything daily")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is True
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="daily", interests=[])
+
+    def test_known_interest_matched(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to ransomware alerts weekly")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is True
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="weekly", interests=["ransomware"])
 
     def test_default_frequency_is_daily(self, mocker):
         from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
         from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com", keywords=[])
-        notification_agent(state)
-        job = json.loads(mock_redis.lpush.call_args[0][1])
-        assert job["payload"]["frequency"] == "daily"
+        state = make_state(user_input="subscribe vishak@example.com to malware")
+        result = notification_agent(state)
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="daily", interests=["malware"])
 
-    def test_job_pushed_to_digest_queue(self, mocker):
+    def test_multi_turn_gathers_email_from_prior_subscribe_turn(self, mocker):
         from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
         from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com", keywords=[])
-        notification_agent(state)
-        assert mock_redis.lpush.call_args[0][0] == "digest-jobs"
-
-    def test_notification_triggered_set_true(self, mocker):
-        from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
-        from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com", keywords=[])
+        history = [
+            {"role": "user", "content": "subscribe me daily", "intent": "subscribe"},
+            {"role": "assistant", "content": "what email should I use?"},
+        ]
+        state = make_state(user_input="vishak@example.com, ransomware please", chat_history=history)
         result = notification_agent(state)
         assert result["notification_triggered"] is True
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="daily", interests=["ransomware"])
+
+    def test_unrelated_prior_turn_not_included(self, mocker):
+        from agents.notification import notification_agent
+        history = [
+            {"role": "user", "content": "show me ransomware news", "intent": "search"},
+            {"role": "assistant", "content": "here are some articles"},
+        ]
+        state = make_state(user_input="subscribe me daily", chat_history=history)
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "email" in result["notification_message"].lower()

--- a/api-service/tests/test_notification.py
+++ b/api-service/tests/test_notification.py
@@ -55,6 +55,17 @@ class TestNotificationAgent:
         assert result["notification_triggered"] is True
         mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="weekly", interests=["ransomware"])
 
+    def test_unsupported_frequency_asks_clarifying_question(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to malware monthly")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "daily or weekly" in result["notification_message"]
+        mock_db.create_subscriber.assert_not_called()
+
     def test_default_frequency_is_daily(self, mocker):
         from agents import notification as notification_module
         mock_db = MagicMock()

--- a/api-service/tests/test_notification.py
+++ b/api-service/tests/test_notification.py
@@ -65,6 +65,17 @@ class TestNotificationAgent:
         result = notification_agent(state)
         mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="daily", interests=["malware"])
 
+    def test_newly_added_interest_tags_matched(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to phishing and zero-day alerts weekly")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is True
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="weekly", interests=["phishing", "zero-day"])
+
     def test_multi_turn_gathers_email_from_prior_subscribe_turn(self, mocker):
         from agents import notification as notification_module
         mock_db = MagicMock()

--- a/api-service/tests/test_notification.py
+++ b/api-service/tests/test_notification.py
@@ -26,6 +26,13 @@ class TestNotificationAgent:
         assert result["notification_triggered"] is False
         assert "email" in result["notification_message"].lower()
 
+    def test_malformed_email_treated_as_missing(self, mocker):
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe a..b@x.com to malware alerts daily")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "email" in result["notification_message"].lower()
+
     def test_asks_for_interests_when_no_known_tag_matched(self, mocker):
         from agents.notification import notification_agent
         state = make_state(user_input="subscribe vishak@example.com to cybersecurity news")
@@ -65,6 +72,17 @@ class TestNotificationAgent:
         assert result["notification_triggered"] is False
         assert "daily or weekly" in result["notification_message"]
         mock_db.create_subscriber.assert_not_called()
+
+    def test_db_failure_returns_error_message_not_false_success(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = False
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to malware daily")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "went wrong" in result["notification_message"]
 
     def test_default_frequency_is_daily(self, mocker):
         from agents import notification as notification_module

--- a/api-service/tests/test_subscriber_model.py
+++ b/api-service/tests/test_subscriber_model.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock
+
+from models.SubscriberModel import SubscriberDB
+
+
+def make_conn_mock():
+    """Build a mock get_connection() context manager returning a mock cursor."""
+    mock_cur = MagicMock()
+    mock_cur_cm = MagicMock()
+    mock_cur_cm.__enter__.return_value = mock_cur
+    mock_cur_cm.__exit__.return_value = False
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cur_cm
+
+    mock_conn_cm = MagicMock()
+    mock_conn_cm.__enter__.return_value = mock_conn
+    mock_conn_cm.__exit__.return_value = False
+
+    return mock_conn_cm, mock_conn, mock_cur
+
+
+class TestSubscriberDB:
+    def test_creates_subscriber_and_interests(self, mocker):
+        from models import SubscriberModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = {"id": "subscriber-uuid-1"}
+        mocker.patch.object(SubscriberModel, "get_connection", return_value=conn_cm)
+
+        db = SubscriberDB()
+        result = db.create_subscriber(email="test@example.com", frequency="daily", interests=["ransomware", "malware"])
+
+        assert result is True
+        first_sql, first_params = mock_cur.execute.call_args_list[0][0]
+        assert "INSERT INTO subscribers" in first_sql
+        assert "ON CONFLICT (email) DO UPDATE" in first_sql
+        assert first_params == {"email": "test@example.com", "frequency": "daily"}
+
+        interest_calls = mock_cur.execute.call_args_list[1:]
+        assert len(interest_calls) == 2
+        tags_inserted = {call[0][1]["tag"] for call in interest_calls}
+        assert tags_inserted == {"ransomware", "malware"}
+        mock_conn.commit.assert_called_once()
+
+    def test_no_interests_still_creates_subscriber(self, mocker):
+        from models import SubscriberModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = {"id": "subscriber-uuid-2"}
+        mocker.patch.object(SubscriberModel, "get_connection", return_value=conn_cm)
+
+        db = SubscriberDB()
+        result = db.create_subscriber(email="test2@example.com")
+
+        assert result is True
+        assert mock_cur.execute.call_count == 1
+        mock_conn.commit.assert_called_once()
+
+    def test_existing_interests_not_deleted_on_conflict(self, mocker):
+        """Merge semantics: re-subscribing shouldn't wipe out previously
+        stored interests that aren't mentioned again. ON CONFLICT DO NOTHING
+        only guards against duplicate rows for the same tag, it's not a
+        replace. If this test breaks, that behavior changed, worth a second
+        look before assuming it's an improvement, see the accumulate vs
+        replace tradeoff in the PR."""
+        from models import SubscriberModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = {"id": "subscriber-uuid-3"}
+        mocker.patch.object(SubscriberModel, "get_connection", return_value=conn_cm)
+
+        db = SubscriberDB()
+        db.create_subscriber(email="test3@example.com", interests=["cve"])
+
+        all_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+        assert not any("DELETE" in sql for sql in all_sql)
+        assert any("ON CONFLICT DO NOTHING" in sql for sql in all_sql)
+
+    def test_returns_false_on_db_error(self, mocker):
+        from models import SubscriberModel
+        mocker.patch.object(SubscriberModel, "get_connection", side_effect=Exception("connection refused"))
+
+        db = SubscriberDB()
+        result = db.create_subscriber(email="test4@example.com", interests=["malware"])
+
+        assert result is False


### PR DESCRIPTION
## Description
NotificationAgent pushed a job to a digest-jobs Redis queue whenever chat detected subscribe intent, but nothing ever consumed that queue. notification-service's worker.py only polls Postgres directly on a timer, confirmed via its Dockerfile, it's the only entrypoint and never reads from Redis at all. So subscribing via chat has looked like it worked since week 4, agent responds, notification_triggered gets set true, but no row ever landed in subscribers. Confirmed with a repo-wide grep for INSERT INTO subscribers, zero results anywhere.

Fix replaces the dead queue push with a real insert, using a new SubscriberDB.create_subscriber in models/SubscriberModel.py, same pattern as NewsModel.py. This is meant to be the one shared insert path, the upcoming /subscribe form route will call the same function so there's never two places writing subscriber rows.

Also fixed two related bugs in the same code path. Email extraction had no fallback, if none was found it silently proceeded with an empty string. Interest extraction didn't filter generic words either, "subscribe me to cybersecurity news" produced interests like ["cybersecurity", "news"] that don't match any real category. Now the agent checks against a known tag set (malware, ransomware, cve, data breach, vulnerability) and asks a clarifying question in chat if email or a real interest is missing, instead of silently completing with junk data. This needed one more small change, chat_history entries now also store the intent that was classified for that turn, so the agent can scan backward through a contiguous run of subscribe-intent turns and gather info across a multi-turn clarification without picking up unrelated earlier messages.

responder.py now reads the actual message NotificationAgent produced instead of a hardcoded "Subscribed successfully" regardless of outcome.

Only touches api-service/, nothing else changed.

## Related Issue
#221

## Motivation and Context
Chat-based subscribe has been silently non-functional since week 4, presented as working in tests because they mock Redis and can confirm the push happened without being able to catch that nothing downstream ever reads it.

## How Has This Been Tested?
Ran locally via python3 -m pytest tests/ -v, all 40 tests pass, including new dedicated coverage for SubscriberModel itself, create plus reactivate on conflict, no-interests case, DB error handling, and a test explicitly locking in that re-subscribing doesn't delete previously stored interests:

- missing email asks for it instead of proceeding
- no matching interest and no "everything" asks which topics
- "everything" is accepted as a valid choice, no tag filter
- known interest correctly extracted and passed to the insert
- multi-turn: email given in one turn, interests in the next, still gathered correctly
- unrelated prior turns (different intent) don't leak into a later subscribe attempt

Also verified against the real local postgres container outside the test suite, called create_subscriber directly: first call created a real row with correct email/frequency/status and both interest tags, second call with the same email and a different frequency correctly reactivated and updated in place instead of duplicating, row count stayed at 1, and the new interest tag was added while the old ones were preserved. Cleaned up the test row after.

One thing worth flagging honestly: interest tags currently accumulate rather than replace on re-subscribe, so there's no way yet to remove a topic you no longer want, only add new ones. Considered switching to full replace instead but that has a worse failure mode, someone adding one new topic later without re-listing everything would silently lose their existing subscriptions. Merge is the safer default until there's an explicit way to remove a topic.

## Screenshots (if appropriate):
<img width="1568" height="319" alt="image" src="https://github.com/user-attachments/assets/a19ae8ae-a087-4d05-a599-364b54603000" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
