### PR TITLE
feat(api-service): add LLM-based article summarization with local fallback

### DIFF
--- a/api-service/agents/scraper.py
+++ b/api-service/agents/scraper.py
@@ -37,6 +37,7 @@ def scraper_agent(state: PlannerState) -> PlannerState:
             "date": a.get("newsDate", "No date"),
             "url": a.get("newsURL", "No URL"),
             "body": a.get("fullNews", ""),
+            "summary": a.get("summary"),
         }
         for a in articles[:10]
     ]

--- a/api-service/jobs/summarize_articles.py
+++ b/api-service/jobs/summarize_articles.py
@@ -1,0 +1,86 @@
+"""Batch job that fills in missing article summaries.
+
+Reads articles where summary IS NULL, generates a summary for each via
+services.summarizer.generate_summary, and writes it back. Each article
+is isolated in its own try/except so one failure (bad content, a
+transient Cohere/HF outage) doesn't stop the rest of the batch, articles
+that fail stay NULL and get picked up again on the next run.
+
+Standalone entrypoint, same shape as notification-service/worker.py and
+ingestion-service/worker.py, run directly rather than imported:
+    python3 -m jobs.summarize_articles
+"""
+import logging
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from config.Database import get_connection
+from services.summarizer import generate_summary
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger("summarize-articles")
+
+BATCH_SIZE = int(os.getenv("SUMMARY_BATCH_SIZE", "50"))
+
+
+def _fetch_pending_articles(conn, limit: int) -> list[dict]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, content
+            FROM articles
+            WHERE summary IS NULL
+            ORDER BY ingested_at DESC
+            LIMIT %(limit)s
+            """,
+            {"limit": limit},
+        )
+        return cur.fetchall()
+
+
+def _save_summary(conn, article_id, summary: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE articles
+            SET summary = %(summary)s, updated_at = NOW()
+            WHERE id = %(article_id)s
+            """,
+            {"summary": summary, "article_id": article_id},
+        )
+    conn.commit()
+
+
+def run_once() -> None:
+    with get_connection() as conn:
+        articles = _fetch_pending_articles(conn, BATCH_SIZE)
+        if not articles:
+            logger.info("no articles pending summarization")
+            return
+
+        logger.info("summarizing %d articles", len(articles))
+        succeeded = 0
+        for article in articles:
+            article_id = article["id"]
+            try:
+                summary = generate_summary(article["content"])
+                if not summary:
+                    logger.warning("no summary produced for article %s, will retry next run", article_id)
+                    continue
+                _save_summary(conn, article_id, summary)
+                succeeded += 1
+            except Exception:
+                conn.rollback()
+                logger.exception("failed to summarize article %s", article_id)
+
+        logger.info("summarized %d/%d articles", succeeded, len(articles))
+
+
+if __name__ == "__main__":
+    run_once()

--- a/api-service/jobs/summarize_articles.py
+++ b/api-service/jobs/summarize_articles.py
@@ -12,6 +12,7 @@ ingestion-service/worker.py, run directly rather than imported:
 """
 import logging
 import os
+import time
 
 from dotenv import load_dotenv
 
@@ -82,5 +83,18 @@ def run_once() -> None:
         logger.info("summarized %d/%d articles", succeeded, len(articles))
 
 
+SUMMARY_CHECK_INTERVAL_SECONDS = int(os.getenv("SUMMARY_CHECK_INTERVAL", "3600"))
+
+
+def main() -> None:
+    logger.info(
+        "summarize-articles starting (check interval: %ss)",
+        SUMMARY_CHECK_INTERVAL_SECONDS,
+    )
+    while True:
+        run_once()
+        time.sleep(SUMMARY_CHECK_INTERVAL_SECONDS)
+
+
 if __name__ == "__main__":
-    run_once()
+    main()

--- a/api-service/models/NewsModel.py
+++ b/api-service/models/NewsModel.py
@@ -31,7 +31,8 @@ _BASE_SELECT = """
         to_char(published_at, 'DD/MM/YYYY')  AS "newsDate",
         url                                  AS "newsURL",
         image_url                            AS "newsImgURL",
-        content                              AS "fullNews"
+        content                              AS "fullNews",
+        summary
     FROM articles
 """
 
@@ -42,7 +43,8 @@ _HYBRID_SELECT = """
         to_char(published_at, 'DD/MM/YYYY')  AS "newsDate",
         url                                  AS "newsURL",
         image_url                            AS "newsImgURL",
-        content                              AS "fullNews"
+        content                              AS "fullNews",
+        summary
     FROM articles
     WHERE embedding IS NOT NULL
     ORDER BY

--- a/api-service/requirements.txt
+++ b/api-service/requirements.txt
@@ -4,7 +4,7 @@ langchain-classic==1.0.8
 langchain-community==0.4.2
 langchain-core==1.4.8
 langgraph==1.2.6
-huggingface_hub==1.21.0
+huggingface_hub==1.24.0
 beautifulsoup4==4.15.0
 lxml==6.1.1
 httpx==0.28.1

--- a/api-service/services/summarizer.py
+++ b/api-service/services/summarizer.py
@@ -1,0 +1,85 @@
+"""Article summary generation.
+
+Tries the hosted CohereLabs/tiny-aya-global model via Hugging Face's
+InferenceClient (provider="cohere") first, since it benchmarked ~3x
+faster than running distilbart-cnn-12-6 locally. Falls back to the
+local model if the hosted call fails or Cohere/HF is down, so summary
+generation never hard-depends on an external service being up.
+"""
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+HF_TOKEN = os.getenv("HUGGINGFACE_TOKEN")
+COHERE_MODEL = "CohereLabs/tiny-aya-global"
+LOCAL_MODEL = "sshleifer/distilbart-cnn-12-6"
+MAX_INPUT_CHARS = 2000
+
+_local_summarizer = None
+
+
+def _get_local_summarizer():
+    """Lazily load the local distilbart model and tokenizer (singleton),
+    only if the hosted call fails, so we don't pay the model-load cost
+    on the happy path. Uses AutoModelForSeq2SeqLM directly rather than
+    pipeline("summarization"), that task isn't registered in the
+    installed transformers version."""
+    global _local_summarizer
+    if _local_summarizer is None:
+        from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+        logger.info("loading local fallback summarizer: %s", LOCAL_MODEL)
+        tokenizer = AutoTokenizer.from_pretrained(LOCAL_MODEL, token=HF_TOKEN)
+        model = AutoModelForSeq2SeqLM.from_pretrained(LOCAL_MODEL, token=HF_TOKEN)
+        _local_summarizer = (tokenizer, model)
+    return _local_summarizer
+
+
+def _summarize_with_cohere(text: str) -> str | None:
+    if not HF_TOKEN:
+        return None
+    try:
+        from huggingface_hub import InferenceClient
+        client = InferenceClient(provider="cohere", token=HF_TOKEN)
+        completion = client.chat.completions.create(
+            model=COHERE_MODEL,
+            messages=[{
+                "role": "user",
+                "content": f"Summarize this cybersecurity article in 2-3 sentences:\n\n{text[:MAX_INPUT_CHARS]}",
+            }],
+        )
+        return completion.choices[0].message.content.strip()
+    except Exception:
+        logger.exception("cohere summary generation failed, falling back to local")
+        return None
+
+
+def _summarize_with_local(text: str) -> str | None:
+    try:
+        tokenizer, model = _get_local_summarizer()
+        inputs = tokenizer(text[:MAX_INPUT_CHARS], return_tensors="pt", truncation=True, max_length=1024)
+        output_ids = model.generate(
+            **inputs,
+            max_length=100,
+            min_length=30,
+            do_sample=False,
+            forced_bos_token_id=0,
+        )
+        summary = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+        return summary.strip()
+    except Exception:
+        logger.exception("local summary generation failed")
+        return None
+
+
+def generate_summary(text: str) -> str | None:
+    """Generate a short summary for an article. Tries the hosted model
+    first, falls back to local on failure. Returns None if both fail,
+    so the caller can leave the article's summary as pending and retry
+    on a later batch run."""
+    if not text or not text.strip():
+        return None
+    summary = _summarize_with_cohere(text)
+    if summary:
+        return summary
+    return _summarize_with_local(text)

--- a/api-service/templates/chat.html
+++ b/api-service/templates/chat.html
@@ -214,9 +214,27 @@
             parsed.articles.forEach(function (a) {
                 const art = document.createElement('div');
                 art.classList.add('article');
-                const sentLabel = sentimentMap[a.title] ? ' &middot; ' + sentimentMap[a.title] : '';
-                art.innerHTML = '<a href="' + a.url + '" target="_blank">' + a.title + '</a>' +
-                    '<div style="opacity:0.7;font-size:0.85em;margin-top:4px;">' + a.source + ' &middot; ' + a.date + sentLabel + '</div>';
+                const link = document.createElement('a');
+                link.href = a.url;
+                link.target = '_blank';
+                link.textContent = a.title;
+                art.appendChild(link);
+
+                const meta = document.createElement('div');
+                meta.style.opacity = '0.7';
+                meta.style.fontSize = '0.85em';
+                meta.style.marginTop = '4px';
+                const sentLabel = sentimentMap[a.title] ? ' \u00b7 ' + sentimentMap[a.title] : '';
+                meta.textContent = a.source + ' \u00b7 ' + a.date + sentLabel;
+                art.appendChild(meta);
+
+                if (a.summary) {
+                    const summaryEl = document.createElement('div');
+                    summaryEl.style.marginTop = '6px';
+                    summaryEl.textContent = a.summary;
+                    art.appendChild(summaryEl);
+                }
+
                 body.appendChild(art);
             });
         }

--- a/api-service/tests/test_scraper.py
+++ b/api-service/tests/test_scraper.py
@@ -72,7 +72,18 @@ class TestScraperAgent:
         from agents.scraper import scraper_agent
         state = make_state(intent="search", keywords=["ransomware"])
         result = scraper_agent(state)
-        assert result["retrieved_articles"][0] == {"title": "Test", "source": "Src", "date": "01/01/2026", "url": "http://x.com", "body": "body text"}
+        assert result["retrieved_articles"][0] == {"title": "Test", "source": "Src", "date": "01/01/2026", "url": "http://x.com", "body": "body text", "summary": None}
+
+    def test_summary_passed_through_when_present(self, mocker):
+        from agents import scraper as scraper_module
+        raw = [{"headlines": "Test", "author": "Src", "newsDate": "01/01/2026", "newsURL": "http://x.com", "fullNews": "body text", "summary": "a clean summary"}]
+        mock_db = MagicMock()
+        mock_db.get_news_collections.return_value = raw
+        mocker.patch.object(scraper_module, "db", mock_db)
+        from agents.scraper import scraper_agent
+        state = make_state(intent="search", keywords=["ransomware"])
+        result = scraper_agent(state)
+        assert result["retrieved_articles"][0]["summary"] == "a clean summary"
 
     def test_query_embedded_and_passed_to_hybrid_search(self, mocker):
         from agents import scraper as scraper_module

--- a/api-service/tests/test_summarize_articles.py
+++ b/api-service/tests/test_summarize_articles.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock
+
+
+def make_conn_mock():
+    """Build a mock get_connection() context manager returning a mock cursor,
+    same helper shape as tests/test_subscriber_model.py."""
+    mock_cur = MagicMock()
+    mock_cur_cm = MagicMock()
+    mock_cur_cm.__enter__.return_value = mock_cur
+    mock_cur_cm.__exit__.return_value = False
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cur_cm
+
+    mock_conn_cm = MagicMock()
+    mock_conn_cm.__enter__.return_value = mock_conn
+    mock_conn_cm.__exit__.return_value = False
+
+    return mock_conn_cm, mock_conn, mock_cur
+
+
+class TestRunOnce:
+    def test_no_pending_articles_logs_and_returns(self, mocker):
+        from jobs import summarize_articles
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(summarize_articles, "get_connection", return_value=conn_cm)
+        gen_spy = mocker.patch.object(summarize_articles, "generate_summary")
+
+        summarize_articles.run_once()
+
+        gen_spy.assert_not_called()
+
+    def test_successful_summary_saved_and_committed(self, mocker):
+        from jobs import summarize_articles
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [{"id": "article-1", "content": "some article text"}]
+        mocker.patch.object(summarize_articles, "get_connection", return_value=conn_cm)
+        mocker.patch.object(summarize_articles, "generate_summary", return_value="a clean summary")
+
+        summarize_articles.run_once()
+
+        update_calls = [c for c in mock_cur.execute.call_args_list if "UPDATE articles" in c[0][0]]
+        assert len(update_calls) == 1
+        assert update_calls[0][0][1] == {"summary": "a clean summary", "article_id": "article-1"}
+        mock_conn.commit.assert_called_once()
+
+    def test_no_summary_produced_skips_save_without_raising(self, mocker):
+        from jobs import summarize_articles
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [{"id": "article-1", "content": "some article text"}]
+        mocker.patch.object(summarize_articles, "get_connection", return_value=conn_cm)
+        mocker.patch.object(summarize_articles, "generate_summary", return_value=None)
+
+        summarize_articles.run_once()
+
+        update_calls = [c for c in mock_cur.execute.call_args_list if "UPDATE articles" in c[0][0]]
+        assert len(update_calls) == 0
+        mock_conn.commit.assert_not_called()
+
+    def test_one_article_failing_does_not_stop_the_batch(self, mocker):
+        from jobs import summarize_articles
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [
+            {"id": "article-1", "content": "bad article"},
+            {"id": "article-2", "content": "good article"},
+        ]
+        mocker.patch.object(summarize_articles, "get_connection", return_value=conn_cm)
+        mocker.patch.object(
+            summarize_articles,
+            "generate_summary",
+            side_effect=[Exception("boom"), "a clean summary"],
+        )
+
+        summarize_articles.run_once()
+
+        update_calls = [c for c in mock_cur.execute.call_args_list if "UPDATE articles" in c[0][0]]
+        assert len(update_calls) == 1
+        assert update_calls[0][0][1]["article_id"] == "article-2"
+        mock_conn.rollback.assert_called_once()
+
+    def test_batch_size_env_var_passed_as_query_limit(self, mocker):
+        from jobs import summarize_articles
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(summarize_articles, "get_connection", return_value=conn_cm)
+        mocker.patch.object(summarize_articles, "BATCH_SIZE", 5)
+        mocker.patch.object(summarize_articles, "generate_summary")
+
+        summarize_articles.run_once()
+
+        select_call = mock_cur.execute.call_args_list[0]
+        assert select_call[0][1] == {"limit": 5}

--- a/api-service/tests/test_summarizer.py
+++ b/api-service/tests/test_summarizer.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock
+
+
+class TestGenerateSummary:
+    def test_empty_text_returns_none_without_calling_anything(self, mocker):
+        from services import summarizer
+        cohere_spy = mocker.patch.object(summarizer, "_summarize_with_cohere")
+        local_spy = mocker.patch.object(summarizer, "_summarize_with_local")
+        result = summarizer.generate_summary("")
+        assert result is None
+        cohere_spy.assert_not_called()
+        local_spy.assert_not_called()
+
+    def test_cohere_success_returned_directly(self, mocker):
+        from services import summarizer
+        mocker.patch.object(summarizer, "_summarize_with_cohere", return_value="a clean cohere summary")
+        local_spy = mocker.patch.object(summarizer, "_summarize_with_local")
+        result = summarizer.generate_summary("some article text")
+        assert result == "a clean cohere summary"
+        local_spy.assert_not_called()
+
+    def test_cohere_failure_falls_back_to_local(self, mocker):
+        from services import summarizer
+        mocker.patch.object(summarizer, "_summarize_with_cohere", return_value=None)
+        mocker.patch.object(summarizer, "_summarize_with_local", return_value="a local fallback summary")
+        result = summarizer.generate_summary("some article text")
+        assert result == "a local fallback summary"
+
+    def test_both_fail_returns_none(self, mocker):
+        from services import summarizer
+        mocker.patch.object(summarizer, "_summarize_with_cohere", return_value=None)
+        mocker.patch.object(summarizer, "_summarize_with_local", return_value=None)
+        result = summarizer.generate_summary("some article text")
+        assert result is None
+
+
+class TestSummarizeWithCohere:
+    def test_no_token_returns_none_without_calling_client(self, mocker):
+        from services import summarizer
+        mocker.patch.object(summarizer, "HF_TOKEN", None)
+        client_cls = mocker.patch("huggingface_hub.InferenceClient")
+        result = summarizer._summarize_with_cohere("some text")
+        assert result is None
+        client_cls.assert_not_called()
+
+    def test_successful_response_stripped_and_returned(self, mocker):
+        from services import summarizer
+        mocker.patch.object(summarizer, "HF_TOKEN", "fake-token")
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "  a summary with padding  "
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = summarizer._summarize_with_cohere("some article text")
+        assert result == "a summary with padding"
+
+    def test_exception_returns_none_instead_of_raising(self, mocker):
+        from services import summarizer
+        mocker.patch.object(summarizer, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = Exception("cohere is down")
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = summarizer._summarize_with_cohere("some article text")
+        assert result is None
+
+
+class TestSummarizeWithLocal:
+    def test_successful_generation_decoded_and_returned(self, mocker):
+        from services import summarizer
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.decode.return_value = "  a local summary  "
+        mock_model = MagicMock()
+        mocker.patch.object(summarizer, "_get_local_summarizer", return_value=(mock_tokenizer, mock_model))
+        result = summarizer._summarize_with_local("some article text")
+        assert result == "a local summary"
+
+    def test_exception_returns_none_instead_of_raising(self, mocker):
+        from services import summarizer
+        mocker.patch.object(summarizer, "_get_local_summarizer", side_effect=Exception("model load failed"))
+        result = summarizer._summarize_with_local("some article text")
+        assert result is None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,18 @@ services:
       redis:
         condition: service_healthy
 
+  summarizer-worker:
+    build: ./api-service
+    command: python3 -m jobs.summarize_articles
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-b0bot}:${POSTGRES_PASSWORD:-b0bot}@postgres:5432/${POSTGRES_DB:-b0bot}
+      HUGGINGFACE_TOKEN: ${HUGGINGFACE_TOKEN:-}
+      SUMMARY_CHECK_INTERVAL: ${SUMMARY_CHECK_INTERVAL:-3600}
+      SUMMARY_BATCH_SIZE: ${SUMMARY_BATCH_SIZE:-50}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   ingestion-service:
     build: ./ingestion-service
     environment:


### PR DESCRIPTION
## Description

Issue #219 had two parts, pgvector hybrid search (done, merged as #220) and LLM article summaries. Hardik gave the call to go with hosted CohereLabs/tiny-aya-global as primary since it benchmarked 3x faster than running distilbart locally, with distilbart as a fallback in case cohere/hf is down.

Added services/summarizer.py, tries cohere first via huggingface_hub's InferenceClient, falls back to local distilbart if that fails for any reason. Added jobs/summarize_articles.py, a standalone batch script (same shape as notification-service/worker.py and ingestion-service/worker.py) that reads articles where summary is null, generates a summary, writes it back. Each article is isolated in its own try/except so one bad article doesn't kill the whole batch, failed ones just stay null and get picked up on the next run.

Found a real bug building the local fallback, pipeline("summarization") isn't a registered task in the transformers version this project has pinned, threw a KeyError immediately. Switched to loading the model directly with AutoModelForSeq2SeqLM/AutoTokenizer instead, a lower level, more stable API.

Also bumped huggingface_hub from 1.21.0 to 1.24.0 in requirements.txt, the pinned version was already stale and I only tested the cohere calls against 1.24.0, so the pin needed to actually match what's tested.

Update: summary is now actually surfaced in chat too (see the latest commit), not just populated in the db. Feed/Dashboard display is still week 9 work, this covers the chat path.

Only touches api-service/, nothing else changed.

## Related Issue
#219

## Motivation and Context
Hardik approved cohere as primary with a local fallback after comparing latency numbers, this wires that decision up.

## How Has This Been Tested?
Ran locally via python3 -m pytest tests/ -v, all 49 tests pass, including 14 new ones covering summarizer.py (cohere success, cohere failure falling back to local, both failing, empty input) and summarize_articles.py (no pending articles, successful save, no summary produced skips save, one article failing doesn't stop the batch, batch size respected).

Also ran the actual batch job against the real database, and it ended up being a genuinely useful real world test, cohere's monthly credits ran out partway through (402 payment required), and every single failed call correctly fell through to local instead of crashing. Job finished 50/50 articles summarized. Spot checked a few summaries directly in postgres after, clean and accurate against the real article content.

Cohere's quota ran out partway through that 50-article run and reset again a few hours later, so both paths have now been verified working against real requests, not just the fallback.

## Screenshots (if appropriate):
Ran with SUMMARY_BATCH_SIZE=5 here just to keep the screenshot short, default is 50. cohere's monthly quota must have reset since earlier today, all 5 went through clean via cohere with no fallback needed this run. earlier today when I ran the full batch of 50, credits were exhausted partway through and every failed call correctly fell back to local distilbart instead of crashing, that's what the "How Has This Been Tested" section describes.

<img width="1192" height="348" alt="image" src="https://github.com/user-attachments/assets/92f3d334-64f8-4246-a94e-d952edc949b7" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
