### PR TITLE
feat(api-service): add subscribe form and unsubscribe route

### DIFF
--- a/api-service/agents/notification.py
+++ b/api-service/agents/notification.py
@@ -1,56 +1,87 @@
 import re
-import json
-import hashlib
-import os
-import redis
 from agents.state import PlannerState
+from models.SubscriberModel import SubscriberDB
 
-REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-DIGEST_QUEUE = "digest-jobs"
+KNOWN_INTEREST_TAGS = {"malware", "ransomware", "cve", "data breach", "vulnerability"}
+EVERYTHING_PHRASES = {"everything", "all articles", "all news", "anything", "all topics"}
 
-try:
-    redis_client = redis.from_url(REDIS_URL, decode_responses=True)
-except Exception:
-    redis_client = None
+db = SubscriberDB()
+
 
 def _extract_email(text: str) -> str:
     match = re.search(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", text)
     return match.group(0) if match else ""
+
 
 def _extract_frequency(text: str) -> str:
     if "weekly" in text.lower():
         return "weekly"
     return "daily"
 
+
+def _extract_known_interests(text: str) -> list[str]:
+    lowered = text.lower()
+    return [tag for tag in KNOWN_INTEREST_TAGS if tag in lowered]
+
+
+def _wants_everything(text: str) -> bool:
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in EVERYTHING_PHRASES)
+
+
+def _gather_subscribe_context(state: PlannerState) -> str:
+    """Combine the current message with any prior turns that were also
+    part of this subscribe flow, so a multi-turn clarification (email in
+    one message, topics in the next) still has full context. Stops at the
+    first prior turn that wasn't subscribe intent, so unrelated earlier
+    messages never leak into this.
+    """
+    history = state.get("chat_history") or []
+    parts = []
+    for entry in reversed(history):
+        if entry.get("role") != "user":
+            continue
+        if entry.get("intent") != "subscribe":
+            break
+        parts.append(entry.get("content", ""))
+    parts.reverse()
+    parts.append(state.get("user_input", ""))
+    return " ".join(parts)
+
+
 def notification_agent(state: PlannerState) -> PlannerState:
-    user_input = state.get("user_input", "")
-    keywords = state.get("keywords", [])
+    combined = _gather_subscribe_context(state)
 
-    email = _extract_email(user_input)
-    frequency = _extract_frequency(user_input)
-    # keywords from PlannerAgent become the subscriber's interest tags
-    interests = [k for k in keywords if k not in {"subscribe", "notify", "alert", "digest", "to", "for", "me", "daily", "weekly"}]
+    email = _extract_email(combined)
+    if not email:
+        return {
+            **state,
+            "notification_triggered": False,
+            "notification_message": "what email should I use for the subscription?",
+        }
 
-    payload = {
-        "email": email,
-        "frequency": frequency,
-        "interests": interests,
+    frequency = _extract_frequency(combined)
+    interests = _extract_known_interests(combined)
+    everything = _wants_everything(combined)
+
+    if not interests and not everything:
+        options = ", ".join(sorted(KNOWN_INTEREST_TAGS))
+        return {
+            **state,
+            "notification_triggered": False,
+            "notification_message": f"which topics are you interested in? options are {options}, or say everything for all articles",
+        }
+
+    db.create_subscriber(email=email, frequency=frequency, interests=interests)
+
+    if interests:
+        topics_text = ", ".join(sorted(interests))
+        confirm = f"subscribed, you'll get {frequency} digests for {topics_text}"
+    else:
+        confirm = f"subscribed, you'll get {frequency} digests with all articles"
+
+    return {
+        **state,
+        "notification_triggered": True,
+        "notification_message": confirm,
     }
-
-    idempotency_key = "digest:" + hashlib.md5(
-        f"{email}:{frequency}".encode()
-    ).hexdigest()
-
-    job = {
-        "event_type": "article.digest",
-        "idempotency_key": idempotency_key,
-        "payload": payload,
-    }
-
-    if redis_client:
-        try:
-            redis_client.lpush(DIGEST_QUEUE, json.dumps(job))
-        except Exception:
-            pass
-
-    return {**state, "notification_triggered": True}

--- a/api-service/agents/notification.py
+++ b/api-service/agents/notification.py
@@ -12,7 +12,7 @@ db = SubscriberDB()
 
 
 def _extract_email(text: str) -> str:
-    match = re.search(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", text)
+    match = re.search(r"(?<![\w.])[a-zA-Z0-9_%+-]+(?:\.[a-zA-Z0-9_%+-]+)*@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}(?![\w.])", text)
     return match.group(0) if match else ""
 
 
@@ -87,7 +87,13 @@ def notification_agent(state: PlannerState) -> PlannerState:
             "notification_message": f"which topics are you interested in? options are {options}, or say everything for all articles",
         }
 
-    db.create_subscriber(email=email, frequency=frequency, interests=interests)
+    created = db.create_subscriber(email=email, frequency=frequency, interests=interests)
+    if not created:
+        return {
+            **state,
+            "notification_triggered": False,
+            "notification_message": "something went wrong saving your subscription, can you try again in a bit?",
+        }
 
     if interests:
         topics_text = ", ".join(sorted(interests))

--- a/api-service/agents/notification.py
+++ b/api-service/agents/notification.py
@@ -16,9 +16,15 @@ def _extract_email(text: str) -> str:
     return match.group(0) if match else ""
 
 
-def _extract_frequency(text: str) -> str:
-    if "weekly" in text.lower():
+UNSUPPORTED_FREQUENCY_TERMS = {"hourly", "monthly", "biweekly", "quarterly", "real-time", "instant", "every hour", "every 12 hours"}
+
+
+def _extract_frequency(text: str) -> str | None:
+    lowered = text.lower()
+    if "weekly" in lowered:
         return "weekly"
+    if any(term in lowered for term in UNSUPPORTED_FREQUENCY_TERMS):
+        return None
     return "daily"
 
 
@@ -64,6 +70,12 @@ def notification_agent(state: PlannerState) -> PlannerState:
         }
 
     frequency = _extract_frequency(combined)
+    if frequency is None:
+        return {
+            **state,
+            "notification_triggered": False,
+            "notification_message": "only daily or weekly digests are supported right now, which one do you want?",
+        }
     interests = _extract_known_interests(combined)
     everything = _wants_everything(combined)
 

--- a/api-service/agents/notification.py
+++ b/api-service/agents/notification.py
@@ -2,7 +2,10 @@ import re
 from agents.state import PlannerState
 from models.SubscriberModel import SubscriberDB
 
-KNOWN_INTEREST_TAGS = {"malware", "ransomware", "cve", "data breach", "vulnerability"}
+KNOWN_INTEREST_TAGS = {
+    "malware", "ransomware", "cve", "data breach", "vulnerability",
+    "phishing", "zero-day", "data leak", "supply chain", "insider threat",
+}
 EVERYTHING_PHRASES = {"everything", "all articles", "all news", "anything", "all topics"}
 
 db = SubscriberDB()
@@ -21,7 +24,7 @@ def _extract_frequency(text: str) -> str:
 
 def _extract_known_interests(text: str) -> list[str]:
     lowered = text.lower()
-    return [tag for tag in KNOWN_INTEREST_TAGS if tag in lowered]
+    return [tag for tag in sorted(KNOWN_INTEREST_TAGS) if tag in lowered]
 
 
 def _wants_everything(text: str) -> bool:

--- a/api-service/agents/responder.py
+++ b/api-service/agents/responder.py
@@ -23,7 +23,8 @@ def responder_agent(state: PlannerState) -> PlannerState:
     intent = state.get("intent", "search")
 
     if intent == "subscribe":
-        response = {"message": "Subscribed successfully. You will receive digests based on your interests.", "articles": []}
+        message = state.get("notification_message") or "Subscribed successfully."
+        response = {"message": message, "articles": []}
         return {**state, "llm_response": json.dumps(response)}
 
     cache_key = _cache_key(user_input, intent)

--- a/api-service/agents/state.py
+++ b/api-service/agents/state.py
@@ -9,4 +9,5 @@ class PlannerState(TypedDict):
     session_id: Optional[str]
     chat_history: Optional[List[dict]]
     notification_triggered: bool
+    notification_message: Optional[str]
     analysis: Optional[Any]

--- a/api-service/models/SubscriberModel.py
+++ b/api-service/models/SubscriberModel.py
@@ -1,0 +1,54 @@
+"""Postgres-backed subscriber store.
+
+Handles creating and updating subscriber records for the email digest.
+Used by both the /subscribe route and NotificationAgent's chat-based
+subscribe flow, so there's exactly one place that writes to subscribers
+and subscriber_interests, regardless of how someone subscribed.
+"""
+import logging
+
+from config.Database import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+class SubscriberDB:
+    def create_subscriber(self, email: str, frequency: str = "daily", interests: list[str] | None = None) -> bool:
+        """Insert or reactivate a subscriber and their interest tags.
+
+        Existing subscribers (matched by email) are reactivated and have
+        their frequency updated rather than duplicated. Returns False (and
+        logs) if the database is unreachable or the insert fails.
+        """
+        interests = interests or []
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO subscribers (email, digest_frequency, status)
+                    VALUES (%(email)s, %(frequency)s, 'active')
+                    ON CONFLICT (email) DO UPDATE SET
+                        digest_frequency = EXCLUDED.digest_frequency,
+                        status = 'active',
+                        updated_at = NOW()
+                    RETURNING id
+                    """,
+                    {"email": email, "frequency": frequency},
+                )
+                subscriber_id = cur.fetchone()["id"]
+
+                for tag in interests:
+                    cur.execute(
+                        """
+                        INSERT INTO subscriber_interests (subscriber_id, tag)
+                        VALUES (%(subscriber_id)s, %(tag)s)
+                        ON CONFLICT DO NOTHING
+                        """,
+                        {"subscriber_id": subscriber_id, "tag": tag},
+                    )
+
+                conn.commit()
+                return True
+        except Exception as exc:
+            logger.error("Failed to create subscriber: %s", exc)
+            return False

--- a/api-service/models/SubscriberModel.py
+++ b/api-service/models/SubscriberModel.py
@@ -52,3 +52,23 @@ class SubscriberDB:
         except Exception as exc:
             logger.error("Failed to create subscriber: %s", exc)
             return False
+
+    def unsubscribe(self, subscriber_id: str) -> bool:
+        """Set a subscriber's status to unsubscribed. Returns False (and
+        logs) if the id doesn't match a row or the database is unreachable."""
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE subscribers
+                    SET status = 'unsubscribed', updated_at = NOW()
+                    WHERE id = %(subscriber_id)s
+                    """,
+                    {"subscriber_id": subscriber_id},
+                )
+                updated = cur.rowcount > 0
+                conn.commit()
+                return updated
+        except Exception as exc:
+            logger.error("Failed to unsubscribe %s: %s", subscriber_id, exc)
+            return False

--- a/api-service/routes/NewsRoutes.py
+++ b/api-service/routes/NewsRoutes.py
@@ -150,7 +150,7 @@ def chat_route():
 
     response = result["llm_response"]
 
-    history.append({"role": "user", "content": user_input})
+    history.append({"role": "user", "content": user_input, "intent": result.get("intent")})
     history.append({"role": "assistant", "content": response})
     _save_history(session_id, history[-MAX_HISTORY:])
 

--- a/api-service/routes/NewsRoutes.py
+++ b/api-service/routes/NewsRoutes.py
@@ -1,5 +1,7 @@
 from flask import *
 from controllers.NewsController import NewsController
+from models.SubscriberModel import SubscriberDB
+from agents.notification import KNOWN_INTEREST_TAGS
 import json
 import os
 import redis
@@ -157,8 +159,44 @@ def chat_route():
     return jsonify({"response": response}), 200
 
 """
-subscribe stub route
+subscribe form - GET renders the form, POST creates the subscriber row
 """
+db = SubscriberDB()
+
+
+@routes.route("/subscribe", methods=["GET"])
+def subscribe_form_route():
+    return render_template("subscribe.html", interest_tags=sorted(KNOWN_INTEREST_TAGS), active_page="subscribe")
+
+
 @routes.route("/subscribe", methods=["POST"])
 def subscribe_route():
-    return jsonify({"message": "subscription endpoint - coming soon"}), 200
+    data = request.get_json()
+    if not data:
+        return jsonify({"success": False, "message": "invalid request"}), 400
+
+    email = (data.get("email") or "").strip()
+    frequency = data.get("frequency") or "daily"
+    interests = data.get("interests") or []
+
+    if not email:
+        return jsonify({"success": False, "message": "email is required"}), 400
+    if frequency not in ("daily", "weekly"):
+        return jsonify({"success": False, "message": "frequency must be daily or weekly"}), 400
+
+    valid_interests = [tag for tag in interests if tag in KNOWN_INTEREST_TAGS]
+
+    created = db.create_subscriber(email=email, frequency=frequency, interests=valid_interests)
+    if not created:
+        return jsonify({"success": False, "message": "something went wrong saving your subscription, please try again"}), 500
+
+    return jsonify({"success": True, "message": "subscribed, you'll get digests based on your interests"}), 200
+
+
+"""
+unsubscribe route - sets status to unsubscribed
+"""
+@routes.route("/unsubscribe/<subscriber_id>", methods=["GET"])
+def unsubscribe_route(subscriber_id):
+    success = db.unsubscribe(subscriber_id)
+    return render_template("unsubscribe.html", success=success)

--- a/api-service/templates/base.html
+++ b/api-service/templates/base.html
@@ -136,6 +136,7 @@
             <a href="/dashboard" class="{% if active_page == 'home' %}active{% endif %}">Home</a>
             <a href="/sources" class="{% if active_page == 'sources' %}active{% endif %}">Sources</a>
             <a href="/chat" class="{% if active_page == 'chat' %}active{% endif %}">Chat</a>
+            <a href="/subscribe" class="{% if active_page == 'subscribe' %}active{% endif %}">Subscribe</a>
         </nav>
         <button id="theme-toggle" onclick="toggleTheme()">Toggle theme</button>
     </div>

--- a/api-service/templates/subscribe.html
+++ b/api-service/templates/subscribe.html
@@ -1,0 +1,118 @@
+{% extends "base.html" %}
+{% block title %}Subscribe{% endblock %}
+{% block extra_style %}
+#subscribe-container {
+    max-width: 480px;
+    margin: 48px auto;
+    padding: 32px;
+}
+#subscribe-container h1 {
+    font-family: var(--font-heading);
+    font-size: 1.6em;
+    margin-bottom: 8px;
+}
+#subscribe-container p.subtitle {
+    color: var(--color-text-muted-dark);
+    margin-bottom: 24px;
+}
+.form-group {
+    margin-bottom: 20px;
+}
+.form-group label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 0.9em;
+}
+.form-group input[type="email"] {
+    width: 100%;
+    padding: 10px 12px;
+    background: var(--color-surface-dark);
+    border: 1px solid var(--color-border-dark);
+    border-radius: 6px;
+    color: var(--color-text-dark);
+    font-family: var(--font-body);
+}
+.frequency-options label,
+.interest-options label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-right: 16px;
+    margin-bottom: 8px;
+    font-weight: normal;
+}
+#subscribe-submit {
+    background: var(--color-primary);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 24px;
+    cursor: pointer;
+    font-family: var(--font-body);
+}
+#subscribe-message {
+    margin-top: 16px;
+    font-size: 0.9em;
+}
+{% endblock %}
+{% block content %}
+<div id="subscribe-container">
+    <h1>Subscribe to digests</h1>
+    <p class="subtitle">Get cybersecurity news delivered to your inbox.</p>
+    <form id="subscribe-form">
+        <div class="form-group">
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" required>
+        </div>
+        <div class="form-group">
+            <label>Frequency</label>
+            <div class="frequency-options">
+                <label><input type="radio" name="frequency" value="daily" checked> Daily</label>
+                <label><input type="radio" name="frequency" value="weekly"> Weekly</label>
+            </div>
+        </div>
+        <div class="form-group">
+            <label>Interests</label>
+            <div class="interest-options">
+                {% for tag in interest_tags %}
+                <label><input type="checkbox" name="interests" value="{{ tag }}"> {{ tag }}</label>
+                {% endfor %}
+            </div>
+        </div>
+        <button type="submit" id="subscribe-submit">Subscribe</button>
+        <div id="subscribe-message"></div>
+    </form>
+</div>
+{% endblock %}
+{% block extra_script %}
+<script>
+document.getElementById('subscribe-form').addEventListener('submit', function (e) {
+    e.preventDefault();
+    const form = e.target;
+    const messageEl = document.getElementById('subscribe-message');
+    const interests = Array.from(form.querySelectorAll('input[name="interests"]:checked')).map(function (el) {
+        return el.value;
+    });
+    const payload = {
+        email: form.email.value,
+        frequency: form.frequency.value,
+        interests: interests,
+    };
+    fetch('/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+    })
+        .then(function (res) { return res.json(); })
+        .then(function (data) {
+            messageEl.textContent = data.message || '';
+            if (data.success) {
+                form.reset();
+            }
+        })
+        .catch(function () {
+            messageEl.textContent = 'something went wrong, please try again';
+        });
+});
+</script>
+{% endblock %}

--- a/api-service/templates/unsubscribe.html
+++ b/api-service/templates/unsubscribe.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Unsubscribe{% endblock %}
+{% block extra_style %}
+#unsubscribe-container {
+    max-width: 480px;
+    margin: 80px auto;
+    padding: 32px;
+    text-align: center;
+}
+#unsubscribe-container h1 {
+    font-family: var(--font-heading);
+    font-size: 1.5em;
+    margin-bottom: 12px;
+}
+#unsubscribe-container p {
+    color: var(--color-text-muted-dark);
+}
+{% endblock %}
+{% block content %}
+<div id="unsubscribe-container">
+    {% if success %}
+    <h1>You're unsubscribed</h1>
+    <p>You won't receive any more digest emails.</p>
+    {% else %}
+    <h1>Couldn't find that subscription</h1>
+    <p>This link may be expired or already unsubscribed.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/api-service/tests/test_graph_routing.py
+++ b/api-service/tests/test_graph_routing.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import MagicMock
 
 
@@ -29,12 +28,14 @@ class TestGraphRouting:
         from agents import responder as responder_module
         mock_db = MagicMock()
         mocker.patch.object(scraper_module, "db", mock_db)
+        mock_subscriber_db = MagicMock()
+        mock_subscriber_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_subscriber_db)
         mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
         mocker.patch.object(responder_module, "redis_client", mock_redis)
         from agents import agent_graph
         result = agent_graph.invoke({
-            "user_input": "subscribe vishak@example.com daily",
+            "user_input": "subscribe vishak@example.com daily to ransomware alerts",
             "session_id": "test",
             "chat_history": [],
             "notification_triggered": False,

--- a/api-service/tests/test_notification.py
+++ b/api-service/tests/test_notification.py
@@ -1,5 +1,3 @@
-import json
-import pytest
 from unittest.mock import MagicMock
 
 
@@ -13,6 +11,7 @@ def make_state(**kwargs):
         "session_id": "test-session",
         "chat_history": [],
         "notification_triggered": False,
+        "notification_message": None,
         "analysis": None,
     }
     base.update(kwargs)
@@ -20,50 +19,74 @@ def make_state(**kwargs):
 
 
 class TestNotificationAgent:
-    def test_email_extracted(self, mocker):
-        from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
+    def test_asks_for_email_when_missing(self, mocker):
         from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com daily", keywords=["vishak@example.com", "daily"])
-        notification_agent(state)
-        job = json.loads(mock_redis.lpush.call_args[0][1])
-        assert job["payload"]["email"] == "vishak@example.com"
+        state = make_state(user_input="subscribe me to malware alerts daily")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "email" in result["notification_message"].lower()
 
-    def test_weekly_frequency_extracted(self, mocker):
-        from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
+    def test_asks_for_interests_when_no_known_tag_matched(self, mocker):
         from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com weekly", keywords=[])
-        notification_agent(state)
-        job = json.loads(mock_redis.lpush.call_args[0][1])
-        assert job["payload"]["frequency"] == "weekly"
+        state = make_state(user_input="subscribe vishak@example.com to cybersecurity news")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "topics" in result["notification_message"].lower()
+
+    def test_everything_is_a_valid_choice(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to everything daily")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is True
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="daily", interests=[])
+
+    def test_known_interest_matched(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to ransomware alerts weekly")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is True
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="weekly", interests=["ransomware"])
 
     def test_default_frequency_is_daily(self, mocker):
         from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
         from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com", keywords=[])
-        notification_agent(state)
-        job = json.loads(mock_redis.lpush.call_args[0][1])
-        assert job["payload"]["frequency"] == "daily"
+        state = make_state(user_input="subscribe vishak@example.com to malware")
+        result = notification_agent(state)
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="daily", interests=["malware"])
 
-    def test_job_pushed_to_digest_queue(self, mocker):
+    def test_multi_turn_gathers_email_from_prior_subscribe_turn(self, mocker):
         from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
         from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com", keywords=[])
-        notification_agent(state)
-        assert mock_redis.lpush.call_args[0][0] == "digest-jobs"
-
-    def test_notification_triggered_set_true(self, mocker):
-        from agents import notification as notification_module
-        mock_redis = MagicMock()
-        mocker.patch.object(notification_module, "redis_client", mock_redis)
-        from agents.notification import notification_agent
-        state = make_state(user_input="subscribe vishak@example.com", keywords=[])
+        history = [
+            {"role": "user", "content": "subscribe me daily", "intent": "subscribe"},
+            {"role": "assistant", "content": "what email should I use?"},
+        ]
+        state = make_state(user_input="vishak@example.com, ransomware please", chat_history=history)
         result = notification_agent(state)
         assert result["notification_triggered"] is True
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="daily", interests=["ransomware"])
+
+    def test_unrelated_prior_turn_not_included(self, mocker):
+        from agents.notification import notification_agent
+        history = [
+            {"role": "user", "content": "show me ransomware news", "intent": "search"},
+            {"role": "assistant", "content": "here are some articles"},
+        ]
+        state = make_state(user_input="subscribe me daily", chat_history=history)
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "email" in result["notification_message"].lower()

--- a/api-service/tests/test_notification.py
+++ b/api-service/tests/test_notification.py
@@ -55,6 +55,17 @@ class TestNotificationAgent:
         assert result["notification_triggered"] is True
         mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="weekly", interests=["ransomware"])
 
+    def test_unsupported_frequency_asks_clarifying_question(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to malware monthly")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "daily or weekly" in result["notification_message"]
+        mock_db.create_subscriber.assert_not_called()
+
     def test_default_frequency_is_daily(self, mocker):
         from agents import notification as notification_module
         mock_db = MagicMock()

--- a/api-service/tests/test_notification.py
+++ b/api-service/tests/test_notification.py
@@ -65,6 +65,17 @@ class TestNotificationAgent:
         result = notification_agent(state)
         mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="daily", interests=["malware"])
 
+    def test_newly_added_interest_tags_matched(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to phishing and zero-day alerts weekly")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is True
+        mock_db.create_subscriber.assert_called_once_with(email="vishak@example.com", frequency="weekly", interests=["phishing", "zero-day"])
+
     def test_multi_turn_gathers_email_from_prior_subscribe_turn(self, mocker):
         from agents import notification as notification_module
         mock_db = MagicMock()

--- a/api-service/tests/test_notification.py
+++ b/api-service/tests/test_notification.py
@@ -26,6 +26,13 @@ class TestNotificationAgent:
         assert result["notification_triggered"] is False
         assert "email" in result["notification_message"].lower()
 
+    def test_malformed_email_treated_as_missing(self, mocker):
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe a..b@x.com to malware alerts daily")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "email" in result["notification_message"].lower()
+
     def test_asks_for_interests_when_no_known_tag_matched(self, mocker):
         from agents.notification import notification_agent
         state = make_state(user_input="subscribe vishak@example.com to cybersecurity news")
@@ -65,6 +72,17 @@ class TestNotificationAgent:
         assert result["notification_triggered"] is False
         assert "daily or weekly" in result["notification_message"]
         mock_db.create_subscriber.assert_not_called()
+
+    def test_db_failure_returns_error_message_not_false_success(self, mocker):
+        from agents import notification as notification_module
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = False
+        mocker.patch.object(notification_module, "db", mock_db)
+        from agents.notification import notification_agent
+        state = make_state(user_input="subscribe vishak@example.com to malware daily")
+        result = notification_agent(state)
+        assert result["notification_triggered"] is False
+        assert "went wrong" in result["notification_message"]
 
     def test_default_frequency_is_daily(self, mocker):
         from agents import notification as notification_module

--- a/api-service/tests/test_subscribe_routes.py
+++ b/api-service/tests/test_subscribe_routes.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock
+
+
+def _client():
+    from app import app
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+class TestSubscribeFormRoute:
+    def test_get_renders_form_with_interest_tags(self, mocker):
+        client = _client()
+        response = client.get("/subscribe")
+        assert response.status_code == 200
+        assert b"malware" in response.data
+        assert b"ransomware" in response.data
+
+
+class TestSubscribePostRoute:
+    def test_missing_email_returns_400(self, mocker):
+        client = _client()
+        response = client.post("/subscribe", json={"frequency": "daily", "interests": []})
+        assert response.status_code == 400
+        assert response.get_json()["success"] is False
+
+    def test_invalid_frequency_returns_400(self, mocker):
+        client = _client()
+        response = client.post("/subscribe", json={"email": "test@example.com", "frequency": "monthly"})
+        assert response.status_code == 400
+
+    def test_unknown_interest_tags_filtered_out(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(NewsRoutes, "db", mock_db)
+        client = _client()
+        response = client.post("/subscribe", json={
+            "email": "test@example.com",
+            "frequency": "daily",
+            "interests": ["malware", "not-a-real-tag"],
+        })
+        assert response.status_code == 200
+        mock_db.create_subscriber.assert_called_once_with(email="test@example.com", frequency="daily", interests=["malware"])
+
+    def test_db_failure_returns_500(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = False
+        mocker.patch.object(NewsRoutes, "db", mock_db)
+        client = _client()
+        response = client.post("/subscribe", json={"email": "test@example.com", "frequency": "daily", "interests": []})
+        assert response.status_code == 500
+        assert response.get_json()["success"] is False
+
+    def test_successful_subscribe_returns_200(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.create_subscriber.return_value = True
+        mocker.patch.object(NewsRoutes, "db", mock_db)
+        client = _client()
+        response = client.post("/subscribe", json={"email": "test@example.com", "frequency": "weekly", "interests": ["cve"]})
+        assert response.status_code == 200
+        assert response.get_json()["success"] is True
+
+
+class TestUnsubscribeRoute:
+    def test_success_renders_confirmation(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.unsubscribe.return_value = True
+        mocker.patch.object(NewsRoutes, "db", mock_db)
+        client = _client()
+        response = client.get("/unsubscribe/some-uuid")
+        assert response.status_code == 200
+        assert b"unsubscribed" in response.data.lower()
+        mock_db.unsubscribe.assert_called_once_with("some-uuid")
+
+    def test_unknown_id_renders_not_found_message(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.unsubscribe.return_value = False
+        mocker.patch.object(NewsRoutes, "db", mock_db)
+        client = _client()
+        response = client.get("/unsubscribe/nonexistent-uuid")
+        assert response.status_code == 200
+        assert b"couldn" in response.data.lower()

--- a/api-service/tests/test_subscriber_model.py
+++ b/api-service/tests/test_subscriber_model.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock
+
+from models.SubscriberModel import SubscriberDB
+
+
+def make_conn_mock():
+    """Build a mock get_connection() context manager returning a mock cursor."""
+    mock_cur = MagicMock()
+    mock_cur_cm = MagicMock()
+    mock_cur_cm.__enter__.return_value = mock_cur
+    mock_cur_cm.__exit__.return_value = False
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cur_cm
+
+    mock_conn_cm = MagicMock()
+    mock_conn_cm.__enter__.return_value = mock_conn
+    mock_conn_cm.__exit__.return_value = False
+
+    return mock_conn_cm, mock_conn, mock_cur
+
+
+class TestSubscriberDB:
+    def test_creates_subscriber_and_interests(self, mocker):
+        from models import SubscriberModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = {"id": "subscriber-uuid-1"}
+        mocker.patch.object(SubscriberModel, "get_connection", return_value=conn_cm)
+
+        db = SubscriberDB()
+        result = db.create_subscriber(email="test@example.com", frequency="daily", interests=["ransomware", "malware"])
+
+        assert result is True
+        first_sql, first_params = mock_cur.execute.call_args_list[0][0]
+        assert "INSERT INTO subscribers" in first_sql
+        assert "ON CONFLICT (email) DO UPDATE" in first_sql
+        assert first_params == {"email": "test@example.com", "frequency": "daily"}
+
+        interest_calls = mock_cur.execute.call_args_list[1:]
+        assert len(interest_calls) == 2
+        tags_inserted = {call[0][1]["tag"] for call in interest_calls}
+        assert tags_inserted == {"ransomware", "malware"}
+        mock_conn.commit.assert_called_once()
+
+    def test_no_interests_still_creates_subscriber(self, mocker):
+        from models import SubscriberModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = {"id": "subscriber-uuid-2"}
+        mocker.patch.object(SubscriberModel, "get_connection", return_value=conn_cm)
+
+        db = SubscriberDB()
+        result = db.create_subscriber(email="test2@example.com")
+
+        assert result is True
+        assert mock_cur.execute.call_count == 1
+        mock_conn.commit.assert_called_once()
+
+    def test_existing_interests_not_deleted_on_conflict(self, mocker):
+        """Merge semantics: re-subscribing shouldn't wipe out previously
+        stored interests that aren't mentioned again. ON CONFLICT DO NOTHING
+        only guards against duplicate rows for the same tag, it's not a
+        replace. If this test breaks, that behavior changed, worth a second
+        look before assuming it's an improvement, see the accumulate vs
+        replace tradeoff in the PR."""
+        from models import SubscriberModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = {"id": "subscriber-uuid-3"}
+        mocker.patch.object(SubscriberModel, "get_connection", return_value=conn_cm)
+
+        db = SubscriberDB()
+        db.create_subscriber(email="test3@example.com", interests=["cve"])
+
+        all_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+        assert not any("DELETE" in sql for sql in all_sql)
+        assert any("ON CONFLICT DO NOTHING" in sql for sql in all_sql)
+
+    def test_returns_false_on_db_error(self, mocker):
+        from models import SubscriberModel
+        mocker.patch.object(SubscriberModel, "get_connection", side_effect=Exception("connection refused"))
+
+        db = SubscriberDB()
+        result = db.create_subscriber(email="test4@example.com", interests=["malware"])
+
+        assert result is False

--- a/api-service/tests/test_subscriber_model.py
+++ b/api-service/tests/test_subscriber_model.py
@@ -82,3 +82,40 @@ class TestSubscriberDB:
         result = db.create_subscriber(email="test4@example.com", interests=["malware"])
 
         assert result is False
+
+
+class TestUnsubscribe:
+    def test_unsubscribe_sets_status_and_returns_true(self, mocker):
+        from models import SubscriberModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.rowcount = 1
+        mocker.patch.object(SubscriberModel, "get_connection", return_value=conn_cm)
+
+        db = SubscriberDB()
+        result = db.unsubscribe("some-uuid")
+
+        assert result is True
+        sql, params = mock_cur.execute.call_args[0]
+        assert "SET status = 'unsubscribed'" in sql
+        assert params == {"subscriber_id": "some-uuid"}
+        mock_conn.commit.assert_called_once()
+
+    def test_unknown_id_returns_false(self, mocker):
+        from models import SubscriberModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.rowcount = 0
+        mocker.patch.object(SubscriberModel, "get_connection", return_value=conn_cm)
+
+        db = SubscriberDB()
+        result = db.unsubscribe("nonexistent-uuid")
+
+        assert result is False
+
+    def test_returns_false_on_db_error(self, mocker):
+        from models import SubscriberModel
+        mocker.patch.object(SubscriberModel, "get_connection", side_effect=Exception("connection refused"))
+
+        db = SubscriberDB()
+        result = db.unsubscribe("some-uuid")
+
+        assert result is False


### PR DESCRIPTION
## Description
Last piece of week 8 (issue #222). /subscribe only had a POST stub that said "coming soon" and never wrote to the db, and there was no way to unsubscribe anywhere in the app.

Added GET /subscribe that renders a real form, email, frequency (daily/weekly), interest tags as checkboxes pulled from the same KNOWN_INTEREST_TAGS set chat uses, so they can't drift apart. POST /subscribe now actually calls SubscriberDB.create_subscriber, the same shared insert path from #221 that chat-based subscribe uses, so there's still only one place that writes subscriber rows.

Added GET /unsubscribe/<subscriber_id>, sets status to unsubscribed rather than deleting the row, digest_deliveries has a foreign key to subscribers so deleting would either break that or need a cascade that wipes delivery history. get_due_subscribers only selects status = 'active' so an unsubscribed row just stops getting picked up, functionally the same as gone.

Also added a "Subscribe" link to the sidebar since nothing linked to the page at all before this.

This branch is based on fix/notification-agent-subscriber-creation (#221) since it needs SubscriberDB, so the diff includes #221's commits until that merges. Will rebase onto main once #221 lands.

Only touches api-service/, nothing else changed.

## Related Issue
#222

## Motivation and Context
Chat-based subscribe already worked after #221's fix, but there was still no actual subscribe form or any way to unsubscribe, this closes that gap.

## How Has This Been Tested?
Ran locally via python3 -m pytest tests/ -v, all 56 tests pass, including new coverage for SubscriberDB.unsubscribe and the /subscribe and /unsubscribe routes themselves (missing email, invalid frequency, unknown tags filtered out, db failure, success, both unsubscribe outcomes).

Also tested live against the real app. Rebuilt api-service, subscribed a real test email through the actual form in the browser, confirmed the row landed correctly in postgres. Hit /unsubscribe/<that id>, confirmed status flipped to unsubscribed in the db and the page showed the right message. Also tried a bogus id, got the "couldn't find that subscription" message correctly.

Went one step further and rebuilt notification-service too (it was running a stale image from before the real digest logic existed) to confirm the whole pipeline end to end. It correctly found the new subscriber as due and tried to send, only failed because SMTP isn't configured in my local .env, which is expected for local dev, not a bug. Subscribing itself doesn't send an email immediately, that's notification-service's job on its own schedule (default hourly), this just confirms the handoff between subscribe and the digest pipeline actually works.

## Screenshots (if appropriate):
<img width="1512" height="867" alt="image" src="https://github.com/user-attachments/assets/72f6b394-b53b-4a49-8b99-ae2ffff21788" />
<img width="1074" height="240" alt="image" src="https://github.com/user-attachments/assets/3469f7eb-dc57-4978-b3be-b3ac4173899e" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
