### PR TITLE
 Fill CVE, severity, and topic tags during article ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 # ─── HuggingFace Inference API ────────────────────────────────────────────────
 # Get a token at https://huggingface.co/settings/tokens
 HUGGINGFACE_TOKEN=hf_your_token_here
+METADATA_LLM_MODEL=CohereLabs/tiny-aya-global
+METADATA_LLM_PROVIDER=cohere
 
 # ─── Optional Social Connectors ───────────────────────────────────────────────
 # Leave blank to disable. The connector silently skips if the key is absent.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,9 @@ services:
       POLLING_INTERVAL_SECONDS: ${POLLING_INTERVAL_SECONDS:-900}
       RSS_FEED_TIMEOUT: ${RSS_FEED_TIMEOUT:-10}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-sentence-transformers/all-MiniLM-L6-v2}
+      HUGGINGFACE_TOKEN: ${HUGGINGFACE_TOKEN:-}
+      METADATA_LLM_MODEL: ${METADATA_LLM_MODEL:-CohereLabs/tiny-aya-global}
+      METADATA_LLM_PROVIDER: ${METADATA_LLM_PROVIDER:-cohere}
     depends_on:
       postgres:
         condition: service_healthy

--- a/ingestion-service/README.md
+++ b/ingestion-service/README.md
@@ -46,5 +46,11 @@ docker compose exec ingestion-service python scripts/publish_test_job.py
 | `POLLING_INTERVAL_SECONDS` | `900` | RSS polling interval |
 | `RSS_FEED_TIMEOUT` | `10` | Per-feed fetch timeout (seconds) |
 | `EMBEDDING_MODEL` | `sentence-transformers/all-MiniLM-L6-v2` | Embedding model |
+| `HUGGINGFACE_TOKEN` | — | HF token for metadata LLM |
+| `METADATA_LLM_MODEL` | `CohereLabs/tiny-aya-global` | Metadata LLM model |
+| `METADATA_LLM_PROVIDER` | `cohere` | HF inference provider |
+
+During ingest, articles get `cve_id` (regex), then `severity`, `affected_system`, and `topic_tags`
+from Cohere via HF when a token is set, with regex/keyword fallback if the call fails.
 
 RSS feed URLs live in `feeds.py`. Shared env defaults and event constants live in `config.py`.

--- a/ingestion-service/config.py
+++ b/ingestion-service/config.py
@@ -28,6 +28,22 @@ EMBEDDING_MODEL = os.getenv(
 EMBEDDING_DIM = 384
 MAX_EMBEDDING_INPUT_CHARS = 512 * 4  # ~512 tokens for MiniLM
 
+# ─── Metadata extraction ─────────────────────────────────────────────────────
+HUGGINGFACE_TOKEN = os.getenv("HUGGINGFACE_TOKEN", "")
+METADATA_LLM_MODEL = os.getenv(
+    "METADATA_LLM_MODEL",
+    "CohereLabs/tiny-aya-global",
+)
+METADATA_LLM_PROVIDER = os.getenv("METADATA_LLM_PROVIDER", "cohere")
+
+KNOWN_TOPIC_TAGS = (
+    "malware",
+    "ransomware",
+    "cve",
+    "data breach",
+    "vulnerability",
+)
+
 # ─── article.discovered event contract ────────────────────────────────────────
 EVENT_ARTICLE_DISCOVERED = "article.discovered"
 ARTICLE_SCHEMA_VERSION = 1

--- a/ingestion-service/db.py
+++ b/ingestion-service/db.py
@@ -60,14 +60,23 @@ def upsert_article(conn, payload: dict, embedding=None, embedding_status: str = 
             INSERT INTO articles (
                 url, url_hash, title, content, author,
                 source_name, feed_url, image_url, published_at,
+                cve_id, severity, affected_system, topic_tags,
                 embedding_status, embedding
             )
             VALUES (
                 %(url)s, %(url_hash)s, %(title)s, %(content)s, %(author)s,
                 %(source_name)s, %(feed_url)s, %(image_url)s, %(published_at)s,
+                %(cve_id)s, %(severity)s, %(affected_system)s, %(topic_tags)s,
                 %(embedding_status)s, %(embedding)s
             )
             ON CONFLICT (url_hash) DO UPDATE SET
+                cve_id = COALESCE(EXCLUDED.cve_id, articles.cve_id),
+                severity = COALESCE(EXCLUDED.severity, articles.severity),
+                affected_system = COALESCE(EXCLUDED.affected_system, articles.affected_system),
+                topic_tags = CASE
+                    WHEN cardinality(EXCLUDED.topic_tags) > 0 THEN EXCLUDED.topic_tags
+                    ELSE articles.topic_tags
+                END,
                 embedding = EXCLUDED.embedding,
                 embedding_status = EXCLUDED.embedding_status,
                 updated_at = NOW()
@@ -83,6 +92,10 @@ def upsert_article(conn, payload: dict, embedding=None, embedding_status: str = 
                 "feed_url": payload.get("feed_url"),
                 "image_url": payload.get("image_url"),
                 "published_at": payload.get("published_at"),
+                "cve_id": payload.get("cve_id"),
+                "severity": payload.get("severity"),
+                "affected_system": payload.get("affected_system"),
+                "topic_tags": payload.get("topic_tags") or [],
                 "embedding_status": embedding_status,
                 "embedding": embedding,
             },

--- a/ingestion-service/db.py
+++ b/ingestion-service/db.py
@@ -97,7 +97,7 @@ def upsert_article(conn, payload: dict, embedding=None, embedding_status: str = 
                 "affected_system": payload.get("affected_system"),
                 "topic_tags": payload.get("topic_tags") or [],
                 "embedding_status": embedding_status,
-                "embedding": embedding,
+                "embedding": embedding if embedding else None,
             },
         )
         row = cur.fetchone()

--- a/ingestion-service/handler.py
+++ b/ingestion-service/handler.py
@@ -10,6 +10,7 @@ import logging
 from config import EVENT_ARTICLE_DISCOVERED
 from db import get_connection, is_processed, mark_processed, upsert_article
 from embeddings import generate_embedding, prepare_embedding_text
+from llm_metadata import enrich_metadata_with_llm
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,12 @@ def handle_article_discovered(data: dict) -> None:
         else:
             embedding_status = "failed"
             logger.warning("embedding failed for article: %s", payload.get("url"))
+
+        metadata = enrich_metadata_with_llm(
+            payload.get("title", ""),
+            payload.get("content_snippet", ""),
+        )
+        payload.update(metadata)
 
         inserted = upsert_article(conn, payload, embedding, embedding_status)
         mark_processed(conn, idempotency_key, event_type)

--- a/ingestion-service/llm_metadata.py
+++ b/ingestion-service/llm_metadata.py
@@ -1,0 +1,140 @@
+"""Optional LLM enrichment for article metadata."""
+
+import json
+import logging
+import re
+
+from config import (
+    HUGGINGFACE_TOKEN,
+    METADATA_LLM_MODEL,
+    METADATA_LLM_PROVIDER,
+)
+from metadata import (
+    enrich_article_metadata,
+    extract_affected_system_fallback,
+    extract_severity_fallback,
+    extract_topic_tags_fallback,
+)
+
+logger = logging.getLogger(__name__)
+
+VALID_SEVERITIES = {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
+JSON_OBJECT_PATTERN = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _build_prompt(title: str, snippet: str) -> str:
+    return (
+        "Analyze this cybersecurity news item and return JSON only.\n"
+        "Use null when unknown. Do not guess.\n"
+        f"severity must be one of CRITICAL, HIGH, MEDIUM, LOW, or null.\n"
+        "Return affected_system as the main product or vendor affected, or null.\n"
+        'Format: {"severity": null, "affected_system": null}\n\n'
+        f"Title: {title}\n"
+        f"Snippet: {snippet}\n"
+    )
+
+
+def _parse_llm_response(raw: str) -> dict | None:
+    if not raw:
+        return None
+
+    candidate = raw.strip()
+    if not candidate.startswith("{"):
+        match = JSON_OBJECT_PATTERN.search(candidate)
+        if not match:
+            return None
+        candidate = match.group(0)
+
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+def _normalize_llm_result(parsed: dict, title: str, snippet: str, cve_id: str | None) -> dict:
+    combined = f"{title}. {snippet}".strip()
+
+    severity = parsed.get("severity")
+    if isinstance(severity, str):
+        severity = severity.strip().upper()
+        if severity not in VALID_SEVERITIES:
+            severity = None
+    else:
+        severity = None
+
+    affected_system = parsed.get("affected_system")
+    if isinstance(affected_system, str):
+        affected_system = affected_system.strip() or None
+    else:
+        affected_system = None
+
+    if severity is None:
+        severity = extract_severity_fallback(combined)
+    if affected_system is None:
+        affected_system = extract_affected_system_fallback(title, combined)
+    topic_tags = extract_topic_tags_fallback(combined, cve_id=cve_id)
+
+    return {
+        "severity": severity,
+        "affected_system": affected_system,
+        "topic_tags": topic_tags,
+    }
+
+
+def _call_cohere(prompt: str) -> str | None:
+    if not HUGGINGFACE_TOKEN:
+        return None
+
+    try:
+        from huggingface_hub import InferenceClient
+    except ImportError:
+        logger.warning("huggingface_hub not installed; skipping metadata LLM")
+        return None
+
+    try:
+        client = InferenceClient(
+            provider=METADATA_LLM_PROVIDER,
+            api_key=HUGGINGFACE_TOKEN,
+        )
+        response = client.chat_completion(
+            messages=[{"role": "user", "content": prompt}],
+            model=METADATA_LLM_MODEL,
+            max_tokens=256,
+            temperature=0,
+        )
+    except Exception:
+        logger.exception("metadata LLM request failed")
+        return None
+
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        return None
+
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", None) if message else None
+    if isinstance(content, str):
+        return content
+    return None
+
+
+def enrich_metadata_with_llm(title: str, snippet: str) -> dict:
+    """Try LLM enrichment, then fill gaps with regex/keyword fallbacks."""
+    base = enrich_article_metadata(title, snippet)
+
+    prompt = _build_prompt(title or "", snippet or "")
+    raw = _call_cohere(prompt)
+    parsed = _parse_llm_response(raw) if raw else None
+    if not parsed:
+        return base
+
+    llm_fields = _normalize_llm_result(parsed, title or "", snippet or "", base.get("cve_id"))
+    return {
+        "cve_id": base.get("cve_id"),
+        "severity": llm_fields["severity"],
+        "affected_system": llm_fields["affected_system"],
+        "topic_tags": llm_fields["topic_tags"] or base.get("topic_tags", []),
+    }

--- a/ingestion-service/metadata.py
+++ b/ingestion-service/metadata.py
@@ -1,0 +1,162 @@
+"""Extract CVE, severity, affected system, and topic tags from article text."""
+
+import html
+import re
+from typing import Iterable
+
+CVE_PATTERN = re.compile(r"CVE-\d{4}-\d{4,}", re.IGNORECASE)
+CVSS_PATTERN = re.compile(
+    r"CVSS\s*(?:score)?\s*(?:of\s*)?[:(]?\s*(\d+(?:\.\d+)?)",
+    re.IGNORECASE,
+)
+HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
+
+KNOWN_TOPIC_TAGS = (
+    "malware",
+    "ransomware",
+    "cve",
+    "data breach",
+    "vulnerability",
+)
+
+SEVERITY_KEYWORDS = (
+    ("CRITICAL", ("critical severity", "critically", " zero-day ", " actively exploited ")),
+    ("HIGH", ("high severity", "high-severity", " severe ", "urgent")),
+    ("MEDIUM", ("medium severity", "moderate")),
+    ("LOW", ("low severity", " low risk ", "minor")),
+)
+
+PRODUCT_HINTS = (
+    "Windows",
+    "Linux",
+    "macOS",
+    "Apache",
+    "nginx",
+    "Chrome",
+    "Firefox",
+    "Microsoft",
+    "Google",
+    "Apple",
+    "Oracle",
+    "VMware",
+    "Cisco",
+    "OpenSSL",
+    "WordPress",
+    "Docker",
+    "Kubernetes",
+)
+
+
+def _strip_html(text: str) -> str:
+    if not text:
+        return ""
+    clean = HTML_TAG_PATTERN.sub(" ", text)
+    return html.unescape(clean).strip()
+
+
+def _normalize_text(title: str, snippet: str) -> str:
+    title = (title or "").strip()
+    snippet = _strip_html(snippet or "")
+    return f"{title}. {snippet}".strip(". ").strip()
+
+
+def extract_cve_id(text: str) -> str | None:
+    match = CVE_PATTERN.search(text or "")
+    if not match:
+        return None
+    return match.group(0).upper()
+
+
+def severity_from_cvss(score: float) -> str | None:
+    if score >= 9.0:
+        return "CRITICAL"
+    if score >= 7.0:
+        return "HIGH"
+    if score >= 4.0:
+        return "MEDIUM"
+    if score >= 0.1:
+        return "LOW"
+    return None
+
+
+def extract_severity_fallback(text: str) -> str | None:
+    if not text:
+        return None
+
+    cvss_match = CVSS_PATTERN.search(text)
+    if cvss_match:
+        try:
+            severity = severity_from_cvss(float(cvss_match.group(1)))
+            if severity:
+                return severity
+        except ValueError:
+            pass
+
+    lowered = text.lower()
+    for severity, phrases in SEVERITY_KEYWORDS:
+        if any(phrase in lowered for phrase in phrases):
+            return severity
+    return None
+
+
+def extract_affected_system_fallback(title: str, text: str) -> str | None:
+    haystack = f"{title or ''} {text or ''}"
+    for product in PRODUCT_HINTS:
+        if re.search(rf"\b{re.escape(product)}\b", haystack, re.IGNORECASE):
+            return product
+    return None
+
+
+def _normalize_tags(tags: Iterable[str]) -> list[str]:
+    allowed = {tag.lower(): tag for tag in KNOWN_TOPIC_TAGS}
+    normalized: list[str] = []
+    for tag in tags:
+        key = (tag or "").strip().lower()
+        if key in allowed and allowed[key] not in normalized:
+            normalized.append(allowed[key])
+    return normalized
+
+
+def extract_topic_tags_fallback(text: str, cve_id: str | None = None) -> list[str]:
+    if not text:
+        text = ""
+
+    lowered = text.lower()
+    tags: list[str] = []
+
+    if cve_id or "cve-" in lowered or " cve " in f" {lowered} ":
+        tags.append("cve")
+    if "ransomware" in lowered:
+        tags.append("ransomware")
+    if "malware" in lowered or "trojan" in lowered:
+        tags.append("malware")
+    if "data breach" in lowered or "breach" in lowered or "leak" in lowered:
+        tags.append("data breach")
+    if (
+        "vulnerability" in lowered
+        or "vulnerabilities" in lowered
+        or "zero-day" in lowered
+        or "zero day" in lowered
+        or "flaw" in lowered
+        or "exploit" in lowered
+    ):
+        tags.append("vulnerability")
+
+    return _normalize_tags(tags)
+
+
+def enrich_article_metadata(title: str, snippet: str) -> dict:
+    """Return metadata fields using regex and keyword heuristics."""
+    combined = _normalize_text(title, snippet)
+    cve_id = extract_cve_id(combined)
+
+    severity = extract_severity_fallback(combined)
+    affected_system = extract_affected_system_fallback(title or "", combined)
+    topic_tags = extract_topic_tags_fallback(combined, cve_id=cve_id)
+
+    return {
+        "cve_id": cve_id,
+        "severity": severity,
+        "affected_system": affected_system,
+        "topic_tags": topic_tags,
+    }

--- a/ingestion-service/requirements.txt
+++ b/ingestion-service/requirements.txt
@@ -5,4 +5,5 @@ psycopg[binary]==3.2.6
 pgvector==0.3.6
 feedparser==6.0.11
 sentence-transformers==3.3.1
+huggingface_hub==1.24.0
 pytest==8.3.5

--- a/ingestion-service/requirements.txt
+++ b/ingestion-service/requirements.txt
@@ -4,6 +4,6 @@ redis==6.4.0
 psycopg[binary]==3.2.6
 pgvector==0.3.6
 feedparser==6.0.11
-sentence-transformers==3.3.1
+sentence-transformers==5.6.0
 huggingface_hub==1.24.0
 pytest==8.3.5

--- a/ingestion-service/tests/test_ingestion_service.py
+++ b/ingestion-service/tests/test_ingestion_service.py
@@ -120,6 +120,15 @@ def fake_conn_ctx():
 
 @patch("handler.mark_processed")
 @patch("handler.upsert_article", return_value=True)
+@patch(
+    "handler.enrich_metadata_with_llm",
+    return_value={
+        "cve_id": "CVE-2024-1",
+        "severity": "HIGH",
+        "affected_system": "Apache",
+        "topic_tags": ["cve"],
+    },
+)
 @patch("handler.generate_embedding", return_value=[0.1, 0.2])
 @patch("handler.prepare_embedding_text", return_value="text")
 @patch("handler.is_processed", return_value=False)
@@ -127,6 +136,7 @@ def test_article_discovered_success_path(
     _mock_is_processed,
     _mock_prepare,
     _mock_generate,
+    _mock_metadata,
     mock_upsert,
     mock_mark,
     fake_conn_ctx,
@@ -148,12 +158,16 @@ def test_article_discovered_success_path(
         handler.handle_article_discovered(event)
 
     mock_upsert.assert_called_once()
+    payload_arg = mock_upsert.call_args[0][1]
+    assert payload_arg["cve_id"] == "CVE-2024-1"
+    assert payload_arg["severity"] == "HIGH"
     mock_mark.assert_called_once_with(conn, "article:hash:discovered", "article.discovered")
     conn.commit.assert_called_once()
 
 
 @patch("handler.mark_processed")
 @patch("handler.upsert_article", return_value=False)
+@patch("handler.enrich_metadata_with_llm", return_value={"cve_id": None, "severity": None, "affected_system": None, "topic_tags": []})
 @patch("handler.generate_embedding", return_value=[])
 @patch("handler.prepare_embedding_text", return_value="text")
 @patch("handler.is_processed", return_value=False)
@@ -161,6 +175,7 @@ def test_article_discovered_embedding_failure_marks_failed(
     _mock_is_processed,
     _mock_prepare,
     _mock_generate,
+    _mock_metadata,
     mock_upsert,
     mock_mark,
     fake_conn_ctx,
@@ -188,6 +203,7 @@ def test_article_discovered_embedding_failure_marks_failed(
 
 @patch("handler.mark_processed")
 @patch("handler.upsert_article", return_value=True)
+@patch("handler.enrich_metadata_with_llm", return_value={"cve_id": None, "severity": None, "affected_system": None, "topic_tags": []})
 @patch("handler.generate_embedding", return_value=[0.1, 0.2])
 @patch("handler.prepare_embedding_text", return_value="")
 @patch("handler.is_processed", return_value=False)
@@ -195,6 +211,7 @@ def test_article_discovered_missing_optional_fields_still_upserts(
     _mock_is_processed,
     mock_prepare,
     _mock_generate,
+    _mock_metadata,
     mock_upsert,
     mock_mark,
     fake_conn_ctx,
@@ -224,6 +241,7 @@ def test_article_discovered_missing_optional_fields_still_upserts(
 
 @patch("handler.mark_processed")
 @patch("handler.upsert_article", return_value=True)
+@patch("handler.enrich_metadata_with_llm", return_value={"cve_id": None, "severity": None, "affected_system": None, "topic_tags": []})
 @patch("handler.generate_embedding", return_value=[0.1, 0.2])
 @patch("handler.prepare_embedding_text", return_value="")
 @patch("handler.is_processed", return_value=False)
@@ -231,6 +249,7 @@ def test_article_discovered_empty_title_and_snippet_still_processes(
     _mock_is_processed,
     mock_prepare,
     _mock_generate,
+    _mock_metadata,
     mock_upsert,
     mock_mark,
     fake_conn_ctx,

--- a/ingestion-service/tests/test_metadata.py
+++ b/ingestion-service/tests/test_metadata.py
@@ -1,0 +1,93 @@
+import os
+import sys
+
+TEST_DIR = os.path.dirname(__file__)
+INGESTION_DIR = os.path.abspath(os.path.join(TEST_DIR, ".."))
+if INGESTION_DIR not in sys.path:
+    sys.path.insert(0, INGESTION_DIR)
+
+import metadata
+from llm_metadata import _normalize_llm_result, _parse_llm_response, enrich_metadata_with_llm
+
+
+def test_extract_cve_id_from_title():
+    title = "Hackers exploit Windmill flaw (CVE-2026-29059)"
+    assert metadata.extract_cve_id(title) == "CVE-2026-29059"
+
+
+def test_extract_cve_id_returns_none_when_missing():
+    assert metadata.extract_cve_id("General security news") is None
+
+
+def test_severity_from_cvss_score():
+    text = "The vulnerability has a CVSS score of 7.5"
+    assert metadata.extract_severity_fallback(text) == "HIGH"
+
+
+def test_extract_topic_tags_fallback_for_ransomware():
+    text = "A new ransomware campaign targets hospitals"
+    tags = metadata.extract_topic_tags_fallback(text)
+    assert "ransomware" in tags
+    assert "malware" not in tags
+
+
+def test_enrich_article_metadata_combined():
+    title = "Critical Apache flaw (CVE-2024-1234) under active exploit"
+    snippet = "Administrators should patch immediately. CVSS score: 9.8"
+    result = metadata.enrich_article_metadata(title, snippet)
+
+    assert result["cve_id"] == "CVE-2024-1234"
+    assert result["severity"] == "CRITICAL"
+    assert "cve" in result["topic_tags"]
+    assert "vulnerability" in result["topic_tags"]
+
+
+def test_extract_affected_system_fallback():
+    title = "Microsoft Windows zero-day exploited in the wild"
+    assert metadata.extract_affected_system_fallback(title, title) == "Windows"
+
+
+def test_parse_llm_response_json():
+    parsed = _parse_llm_response(
+        '{"severity": "HIGH", "affected_system": "Apache", "topic_tags": ["cve"]}'
+    )
+    assert parsed["severity"] == "HIGH"
+    assert parsed["affected_system"] == "Apache"
+
+
+def test_normalize_llm_result_uses_fallback_topic_tags():
+    parsed = {
+        "severity": "LOW",
+        "affected_system": "Chrome",
+        "topic_tags": ["phishing"],
+    }
+    result = _normalize_llm_result(
+        parsed,
+        "Chrome bug fixed",
+        "Google patched a browser issue",
+        "CVE-2024-9999",
+    )
+    assert result["severity"] == "LOW"
+    assert result["affected_system"] == "Chrome"
+    assert result["topic_tags"] == ["cve"]
+
+
+def test_enrich_metadata_falls_back_when_llm_unavailable(monkeypatch):
+    monkeypatch.setattr("llm_metadata._call_cohere", lambda _prompt: None)
+
+    result = enrich_metadata_with_llm(
+        "Ransomware hits hospitals (CVE-2025-1000)",
+        "Critical severity attack",
+    )
+    assert result["cve_id"] == "CVE-2025-1000"
+    assert "ransomware" in result["topic_tags"]
+
+
+def test_enrich_metadata_falls_back_on_failed_llm_response(monkeypatch):
+    monkeypatch.setattr("llm_metadata._call_cohere", lambda _prompt: None)
+
+    result = enrich_metadata_with_llm(
+        "Data breach exposes customer records",
+        "Company confirms leak of user data",
+    )
+    assert "data breach" in result["topic_tags"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds metadata extraction to ingestion-service. CVE ID comes from regex, severity and affected system from Cohere via HuggingFace, topic tags from keywords. Everything saves on upsert. If LLM fails, fallback still runs so ingest doesn't break.

Also fixes failed embeddings crashing upsert and updates deps for Docker build.

## Related Issue
#233 

## Motivation and Context
Articles were going into Postgres with empty CVE and severity fields. Dashboard needs them at ingest time, not later.

## How Has This Been Tested?
Ran pytest tests/ -q — 26 passed.

## Screenshots (if appropriate):
<img width="663" height="697" alt="image" src="https://github.com/user-attachments/assets/9143ad05-04c5-42b7-a282-64d481346d1b" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
