### PR TITLE
feat(api-service,db): add sources page with table-backed source list

### DIFF
--- a/api-service/models/SourceModel.py
+++ b/api-service/models/SourceModel.py
@@ -2,25 +2,56 @@
 Handles listing and creating RSS sources for the sources page. New sources
 are inserted as 'pending' since ingestion-service still reads from the
 hardcoded RSS_FEEDS list in ingestion-service/feeds.py, not this table yet.
+
+get_all_sources caches its result in Redis, same pattern as responder.py's
+chat response cache. Sources rarely change and the page is read far more
+often than it's written to, so caching avoids re-querying every page load.
+Cache is invalidated immediately on a successful create_source, rather than
+waiting out the TTL, so a newly added source shows up right away.
 """
+import json
 import logging
+import os
+import redis
 from config.Database import get_connection
 
 logger = logging.getLogger(__name__)
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+SOURCES_CACHE_KEY = "sources:all"
+SOURCES_CACHE_TTL = 60  # seconds
+
+try:
+    redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+except Exception:
+    redis_client = None
 
 
 class SourceDB:
     def get_all_sources(self) -> list[dict]:
         """Return all sources, newest first. Empty list on any db error."""
+        if redis_client:
+            try:
+                cached = redis_client.get(SOURCES_CACHE_KEY)
+                if cached:
+                    return json.loads(cached)
+            except Exception:
+                pass
         try:
             with get_connection() as conn, conn.cursor() as cur:
                 cur.execute(
                     "SELECT id, name, url, status, created_at FROM sources ORDER BY created_at DESC"
                 )
-                return cur.fetchall()
+                sources = cur.fetchall()
         except Exception as exc:
             logger.error("Failed to fetch sources: %s", exc)
             return []
+        if redis_client:
+            try:
+                redis_client.setex(SOURCES_CACHE_KEY, SOURCES_CACHE_TTL, json.dumps(sources, default=str))
+            except Exception:
+                pass
+        return sources
 
     def create_source(self, name: str, url: str) -> bool | None:
         """Insert a new source as pending. Returns True on success, False if
@@ -38,6 +69,11 @@ class SourceDB:
                 )
                 inserted = cur.fetchone() is not None
                 conn.commit()
+                if inserted and redis_client:
+                    try:
+                        redis_client.delete(SOURCES_CACHE_KEY)
+                    except Exception:
+                        pass
                 return inserted
         except Exception as exc:
             logger.error("Failed to create source: %s", exc)

--- a/api-service/models/SourceModel.py
+++ b/api-service/models/SourceModel.py
@@ -1,0 +1,44 @@
+"""Postgres-backed source store.
+Handles listing and creating RSS sources for the sources page. New sources
+are inserted as 'pending' since ingestion-service still reads from the
+hardcoded RSS_FEEDS list in ingestion-service/feeds.py, not this table yet.
+"""
+import logging
+from config.Database import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+class SourceDB:
+    def get_all_sources(self) -> list[dict]:
+        """Return all sources, newest first. Empty list on any db error."""
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id, name, url, status, created_at FROM sources ORDER BY created_at DESC"
+                )
+                return cur.fetchall()
+        except Exception as exc:
+            logger.error("Failed to fetch sources: %s", exc)
+            return []
+
+    def create_source(self, name: str, url: str) -> bool | None:
+        """Insert a new source as pending. Returns True on success, False if
+        the url already exists, None on a real db error."""
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO sources (name, url, status)
+                    VALUES (%(name)s, %(url)s, 'pending')
+                    ON CONFLICT (url) DO NOTHING
+                    RETURNING id
+                    """,
+                    {"name": name, "url": url},
+                )
+                inserted = cur.fetchone() is not None
+                conn.commit()
+                return inserted
+        except Exception as exc:
+            logger.error("Failed to create source: %s", exc)
+            return None

--- a/api-service/routes/NewsRoutes.py
+++ b/api-service/routes/NewsRoutes.py
@@ -1,6 +1,7 @@
 from flask import *
 from controllers.NewsController import NewsController
 from models.SubscriberModel import SubscriberDB
+from models.SourceModel import SourceDB
 from agents.notification import KNOWN_INTEREST_TAGS
 import json
 import os
@@ -122,11 +123,30 @@ def dashboard_route():
     return render_template("coming_soon.html", active_page="home", page_name="Home")
 
 """
-sources placeholder route, real sources page lands week 9
+sources page - GET lists sources, POST adds a new one (pending until
+ingestion-service reads from this table instead of the hardcoded RSS_FEEDS list)
 """
+source_db = SourceDB()
 @routes.route("/sources", methods=["GET"])
 def sources_route():
-    return render_template("coming_soon.html", active_page="sources", page_name="Sources")
+    return render_template("sources.html", sources=source_db.get_all_sources(), active_page="sources")
+@routes.route("/sources", methods=["POST"])
+def add_source_route():
+    data = request.get_json()
+    if not data:
+        return jsonify({"success": False, "message": "invalid request"}), 400
+    name = (data.get("name") or "").strip()
+    url = (data.get("url") or "").strip()
+    if not name or not url:
+        return jsonify({"success": False, "message": "name and url are required"}), 400
+    if not (url.startswith("http://") or url.startswith("https://")):
+        return jsonify({"success": False, "message": "please enter a valid url"}), 400
+    result = source_db.create_source(name=name, url=url)
+    if result is None:
+        return jsonify({"success": False, "message": "something went wrong, please try again"}), 500
+    if result is False:
+        return jsonify({"success": False, "message": "that source already exists"}), 409
+    return jsonify({"success": True, "message": "source added, pending activation"}), 200
 
 """
 chat route - multi-turn dialogue via LangGraph agents

--- a/api-service/templates/sources.html
+++ b/api-service/templates/sources.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+{% block title %}Sources{% endblock %}
+{% block extra_style %}
+#sources-container {
+    max-width: 720px;
+    margin: 48px auto;
+    padding: 32px;
+}
+#sources-container h1 {
+    font-family: var(--font-heading);
+    font-size: 1.6em;
+    margin-bottom: 8px;
+}
+#sources-container p.subtitle {
+    color: var(--color-text-muted-dark);
+    margin-bottom: 24px;
+}
+#sources-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 32px;
+}
+#sources-table th {
+    text-align: left;
+    font-size: 0.85em;
+    color: var(--color-text-muted-dark);
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--color-border-dark);
+}
+#sources-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--color-border-dark);
+    font-size: 0.9em;
+}
+.status-badge {
+    font-size: 0.75em;
+    padding: 2px 8px;
+    border-radius: 10px;
+}
+.status-active {
+    background: rgba(60, 180, 100, 0.15);
+    color: #3cb464;
+}
+.status-pending {
+    background: rgba(255, 170, 0, 0.15);
+    color: #ffaa00;
+}
+#add-source-form {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+}
+#add-source-form input {
+    padding: 10px 12px;
+    background: var(--color-surface-dark);
+    border: 1px solid var(--color-border-dark);
+    border-radius: 6px;
+    color: var(--color-text-dark);
+    font-family: var(--font-body);
+}
+#source-name { width: 180px; }
+#source-url { flex: 1; }
+#add-source-submit {
+    background: var(--color-primary);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 20px;
+    cursor: pointer;
+    font-family: var(--font-body);
+}
+#add-source-message {
+    margin-top: 12px;
+    font-size: 0.9em;
+}
+{% endblock %}
+{% block content %}
+<div id="sources-container">
+    <h1>Sources</h1>
+    <p class="subtitle">Your Sources</p>
+    <table id="sources-table">
+        <thead>
+            <tr><th>Source</th><th>URL</th><th>Status</th></tr>
+        </thead>
+        <tbody id="sources-tbody">
+            {% for s in sources %}
+            <tr>
+                <td>{{ s.name }}</td>
+                <td>{{ s.url }}</td>
+                <td><span class="status-badge status-{{ s.status }}">{{ s.status }}</span></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <form id="add-source-form">
+        <input type="text" id="source-name" name="name" placeholder="Source name" required>
+        <input type="text" id="source-url" name="url" placeholder="https://example.com/feed" required>
+        <button type="submit" id="add-source-submit">Add</button>
+    </form>
+    <div id="add-source-message"></div>
+</div>
+{% endblock %}
+{% block extra_script %}
+<script>
+document.getElementById('add-source-form').addEventListener('submit', function (e) {
+    e.preventDefault();
+    const form = e.target;
+    const messageEl = document.getElementById('add-source-message');
+    const payload = { name: form.name.value, url: form.url.value };
+    fetch('/sources', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+    })
+        .then(function (res) { return res.json(); })
+        .then(function (data) {
+            messageEl.textContent = data.message || '';
+            if (data.success) {
+                form.reset();
+                const tbody = document.getElementById('sources-tbody');
+                const row = document.createElement('tr');
+                row.innerHTML = '<td>' + payload.name + '</td><td>' + payload.url + '</td>' +
+                    '<td><span class="status-badge status-pending">pending</span></td>';
+                tbody.appendChild(row);
+            }
+        })
+        .catch(function () {
+            messageEl.textContent = 'something went wrong, please try again';
+        });
+});
+</script>
+{% endblock %}

--- a/api-service/tests/test_source_model.py
+++ b/api-service/tests/test_source_model.py
@@ -17,8 +17,37 @@ def make_conn_mock():
 
 
 class TestGetAllSources:
-    def test_returns_rows_on_success(self, mocker):
+    def test_cache_miss_queries_db_and_populates_cache(self, mocker):
         from models import SourceModel
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mocker.patch.object(SourceModel, "redis_client", mock_redis)
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [{"id": "1", "name": "Test", "url": "https://x.com/feed", "status": "active"}]
+        mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
+        db = SourceDB()
+        result = db.get_all_sources()
+        assert result == [{"id": "1", "name": "Test", "url": "https://x.com/feed", "status": "active"}]
+        mock_redis.setex.assert_called_once()
+        cache_key = mock_redis.setex.call_args[0][0]
+        assert cache_key == SourceModel.SOURCES_CACHE_KEY
+
+    def test_cache_hit_skips_db_entirely(self, mocker):
+        from models import SourceModel
+        import json
+        mock_redis = MagicMock()
+        cached_sources = [{"id": "1", "name": "Test", "url": "https://x.com/feed", "status": "active"}]
+        mock_redis.get.return_value = json.dumps(cached_sources)
+        mocker.patch.object(SourceModel, "redis_client", mock_redis)
+        db_connection_spy = mocker.patch.object(SourceModel, "get_connection")
+        db = SourceDB()
+        result = db.get_all_sources()
+        assert result == cached_sources
+        db_connection_spy.assert_not_called()
+
+    def test_no_redis_falls_back_to_db_directly(self, mocker):
+        from models import SourceModel
+        mocker.patch.object(SourceModel, "redis_client", None)
         conn_cm, mock_conn, mock_cur = make_conn_mock()
         mock_cur.fetchall.return_value = [{"id": "1", "name": "Test", "url": "https://x.com/feed", "status": "active"}]
         mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
@@ -28,15 +57,29 @@ class TestGetAllSources:
 
     def test_returns_empty_list_on_db_error(self, mocker):
         from models import SourceModel
+        mocker.patch.object(SourceModel, "redis_client", None)
         mocker.patch.object(SourceModel, "get_connection", side_effect=Exception("db down"))
         db = SourceDB()
         result = db.get_all_sources()
         assert result == []
 
+    def test_redis_error_on_read_falls_back_to_db(self, mocker):
+        from models import SourceModel
+        mock_redis = MagicMock()
+        mock_redis.get.side_effect = Exception("redis down")
+        mocker.patch.object(SourceModel, "redis_client", mock_redis)
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [{"id": "1", "name": "Test", "url": "https://x.com/feed", "status": "active"}]
+        mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
+        db = SourceDB()
+        result = db.get_all_sources()
+        assert result == [{"id": "1", "name": "Test", "url": "https://x.com/feed", "status": "active"}]
+
 
 class TestCreateSource:
     def test_returns_true_on_successful_insert(self, mocker):
         from models import SourceModel
+        mocker.patch.object(SourceModel, "redis_client", None)
         conn_cm, mock_conn, mock_cur = make_conn_mock()
         mock_cur.fetchone.return_value = {"id": "new-uuid"}
         mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
@@ -49,8 +92,20 @@ class TestCreateSource:
         assert params == {"name": "Test Feed", "url": "https://x.com/feed"}
         mock_conn.commit.assert_called_once()
 
+    def test_successful_insert_invalidates_cache(self, mocker):
+        from models import SourceModel
+        mock_redis = MagicMock()
+        mocker.patch.object(SourceModel, "redis_client", mock_redis)
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = {"id": "new-uuid"}
+        mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
+        db = SourceDB()
+        db.create_source(name="Test Feed", url="https://x.com/feed")
+        mock_redis.delete.assert_called_once_with(SourceModel.SOURCES_CACHE_KEY)
+
     def test_returns_false_on_duplicate_url(self, mocker):
         from models import SourceModel
+        mocker.patch.object(SourceModel, "redis_client", None)
         conn_cm, mock_conn, mock_cur = make_conn_mock()
         mock_cur.fetchone.return_value = None
         mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
@@ -58,8 +113,20 @@ class TestCreateSource:
         result = db.create_source(name="Test Feed", url="https://x.com/feed")
         assert result is False
 
+    def test_duplicate_url_does_not_invalidate_cache(self, mocker):
+        from models import SourceModel
+        mock_redis = MagicMock()
+        mocker.patch.object(SourceModel, "redis_client", mock_redis)
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = None
+        mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
+        db = SourceDB()
+        db.create_source(name="Test Feed", url="https://x.com/feed")
+        mock_redis.delete.assert_not_called()
+
     def test_returns_none_on_db_error(self, mocker):
         from models import SourceModel
+        mocker.patch.object(SourceModel, "redis_client", None)
         mocker.patch.object(SourceModel, "get_connection", side_effect=Exception("db down"))
         db = SourceDB()
         result = db.create_source(name="Test Feed", url="https://x.com/feed")

--- a/api-service/tests/test_source_model.py
+++ b/api-service/tests/test_source_model.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock
+from models.SourceModel import SourceDB
+
+
+def make_conn_mock():
+    """Build a mock get_connection() context manager returning a mock cursor."""
+    mock_cur = MagicMock()
+    mock_cur_cm = MagicMock()
+    mock_cur_cm.__enter__.return_value = mock_cur
+    mock_cur_cm.__exit__.return_value = False
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cur_cm
+    mock_conn_cm = MagicMock()
+    mock_conn_cm.__enter__.return_value = mock_conn
+    mock_conn_cm.__exit__.return_value = False
+    return mock_conn_cm, mock_conn, mock_cur
+
+
+class TestGetAllSources:
+    def test_returns_rows_on_success(self, mocker):
+        from models import SourceModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [{"id": "1", "name": "Test", "url": "https://x.com/feed", "status": "active"}]
+        mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
+        db = SourceDB()
+        result = db.get_all_sources()
+        assert result == [{"id": "1", "name": "Test", "url": "https://x.com/feed", "status": "active"}]
+
+    def test_returns_empty_list_on_db_error(self, mocker):
+        from models import SourceModel
+        mocker.patch.object(SourceModel, "get_connection", side_effect=Exception("db down"))
+        db = SourceDB()
+        result = db.get_all_sources()
+        assert result == []
+
+
+class TestCreateSource:
+    def test_returns_true_on_successful_insert(self, mocker):
+        from models import SourceModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = {"id": "new-uuid"}
+        mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
+        db = SourceDB()
+        result = db.create_source(name="Test Feed", url="https://x.com/feed")
+        assert result is True
+        sql, params = mock_cur.execute.call_args[0]
+        assert "INSERT INTO sources" in sql
+        assert "ON CONFLICT (url) DO NOTHING" in sql
+        assert params == {"name": "Test Feed", "url": "https://x.com/feed"}
+        mock_conn.commit.assert_called_once()
+
+    def test_returns_false_on_duplicate_url(self, mocker):
+        from models import SourceModel
+        conn_cm, mock_conn, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = None
+        mocker.patch.object(SourceModel, "get_connection", return_value=conn_cm)
+        db = SourceDB()
+        result = db.create_source(name="Test Feed", url="https://x.com/feed")
+        assert result is False
+
+    def test_returns_none_on_db_error(self, mocker):
+        from models import SourceModel
+        mocker.patch.object(SourceModel, "get_connection", side_effect=Exception("db down"))
+        db = SourceDB()
+        result = db.create_source(name="Test Feed", url="https://x.com/feed")
+        assert result is None

--- a/api-service/tests/test_source_routes.py
+++ b/api-service/tests/test_source_routes.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock
+
+
+def _client():
+    from app import app
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+class TestSourcesGetRoute:
+    def test_get_renders_source_list(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.get_all_sources.return_value = [
+            {"id": "1", "name": "Test Feed", "url": "https://example.com/feed", "status": "active"}
+        ]
+        mocker.patch.object(NewsRoutes, "source_db", mock_db)
+        client = _client()
+        response = client.get("/sources")
+        assert response.status_code == 200
+        assert b"Test Feed" in response.data
+
+
+class TestAddSourceRoute:
+    def test_missing_url_returns_400(self, mocker):
+        client = _client()
+        response = client.post("/sources", json={"name": "Test"})
+        assert response.status_code == 400
+        assert response.get_json()["success"] is False
+
+    def test_invalid_url_format_returns_400(self, mocker):
+        client = _client()
+        response = client.post("/sources", json={"name": "Test", "url": "not-a-url"})
+        assert response.status_code == 400
+        assert response.get_json()["message"] == "please enter a valid url"
+
+    def test_duplicate_url_returns_409(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.create_source.return_value = False
+        mocker.patch.object(NewsRoutes, "source_db", mock_db)
+        client = _client()
+        response = client.post("/sources", json={"name": "Test", "url": "https://example.com/feed"})
+        assert response.status_code == 409
+        assert response.get_json()["message"] == "that source already exists"
+
+    def test_db_error_returns_500(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.create_source.return_value = None
+        mocker.patch.object(NewsRoutes, "source_db", mock_db)
+        client = _client()
+        response = client.post("/sources", json={"name": "Test", "url": "https://example.com/feed"})
+        assert response.status_code == 500
+        assert response.get_json()["success"] is False
+
+    def test_successful_add_returns_200(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.create_source.return_value = True
+        mocker.patch.object(NewsRoutes, "source_db", mock_db)
+        client = _client()
+        response = client.post("/sources", json={"name": "Test Feed", "url": "https://example.com/feed"})
+        assert response.status_code == 200
+        assert response.get_json()["success"] is True
+        mock_db.create_source.assert_called_once_with(name="Test Feed", url="https://example.com/feed")

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -82,6 +82,26 @@ CREATE TABLE IF NOT EXISTS processed_jobs (
     event_type      TEXT NOT NULL,
     processed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+-- ─── Sources ────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS sources (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name       TEXT NOT NULL,
+    url        TEXT NOT NULL UNIQUE,
+    status     TEXT NOT NULL DEFAULT 'pending'
+               CHECK (status IN ('pending','active')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO sources (name, url, status) VALUES
+    ('The Hacker News', 'https://thehackernews.com/feeds/posts/default', 'active'),
+    ('BleepingComputer', 'https://www.bleepingcomputer.com/feed/', 'active'),
+    ('CISA Alerts', 'https://www.cisa.gov/cybersecurity-advisories/all.xml', 'active'),
+    ('Dark Reading', 'https://www.darkreading.com/rss.xml', 'active'),
+    ('KrebsOnSecurity', 'https://krebsonsecurity.com/feed/', 'active'),
+    ('Google Security Blog', 'https://security.googleblog.com/feeds/posts/default', 'active'),
+    ('SANS ISC', 'https://isc.sans.edu/rssfeed.xml', 'active'),
+    ('SecurityWeek', 'https://www.securityweek.com/feed/', 'active')
+ON CONFLICT (url) DO NOTHING;
 
 -- ─── Seed data ─────────────────────────────────────────────────
 -- A few sample articles so the API and UI have something to render before the


### PR DESCRIPTION
## Description
/sources was a coming_soon.html stub. Added a real sources table in postgres, seeded it with the 8 feeds that are currently hardcoded in ingestion-service/feeds.py so the page shows what's actually running, and built a form to add new ones.

For now, ingestion-service still reads from that hardcoded list, not this table. So adding a source here saves it for real, but it won't actually get polled until ingestion-service is wired to read from the sources table instead. New sources show up with a "pending" badge instead of "active" so it's honest about that rather than pretending the add button does more than it does. Sent @AQIB-NAWAB a heads up on this and asked if he can wire poller.py to read from the table alongside the hardcoded list when he gets a chance, not blocking on it for this PR.


## Related Issue
part of #232 (week 9), the sources half only, dashboard is a separate PR.

## Motivation and Context
Sources page didn't exist yet, this is the actual feature per the UI doc.

## How Has This Been Tested?
Tested live against the running containers, not just unit tests. added a new source through the form and confirmed it shows up as pending. Tried adding the same url twice and got the "already exists" message instead of a duplicate row or a silent update. tried a url without http/https and got "please enter a valid url". also checked #231 (aqib's PR) doesn't touch
anything in api-service, no overlap.

11 new tests covering the model layer (get_all_sources, create_source's three return states) and the route layer (all four response paths). all mocked, 82 tests passing total, nothing else broke.

## Screenshots (if appropriate):
<img width="1512" height="867" alt="image" src="https://github.com/user-attachments/assets/2342016a-f281-4095-978a-a9b7458aecc4" />
<img width="1512" height="868" alt="image" src="https://github.com/user-attachments/assets/9ac9e3b3-d004-46b3-a9bf-95c72f9e5928" />
<img width="1511" height="868" alt="image" src="https://github.com/user-attachments/assets/34f874e5-0151-4889-a8ce-4ede0101f280" />
<img width="1512" height="868" alt="image" src="https://github.com/user-attachments/assets/f314aecb-e84a-41b6-8539-da686f892729" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
