### PR TITLE
docs: fix Pinecone index name mismatch between README, NewsModel.py, and Database.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once a user requests our API, it retrieves news data from our knowledge base and
 ```
 https://www.pinecone.io/
 ```
-Login to Pinecone and create a new index with the name `news-index`. Then, add the Pinecone API key in the `.env` file.
+Login to Pinecone and create a new index with a name of your choice. Then, add the Pinecone API key and your chosen index name to the `.env` file as `PINECONE_API_KEY` and `PINECONE_INDEX_NAME` respectively (see `.env.example`).
 
 
 

--- a/config/Database.py
+++ b/config/Database.py
@@ -8,4 +8,3 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 PINECONE_API = dotenv_values(".env").get("PINECONE_API_KEY")
 
 client = Pinecone(api_key=PINECONE_API)
-index_name = "cybernews-index"

--- a/models/NewsModel.py
+++ b/models/NewsModel.py
@@ -5,7 +5,8 @@ class CybernewsDB:
     def __init__(self):
         from sentence_transformers import SentenceTransformer, SparseEncoder
         self.client = client
-        self.index_name = "cybernews-hybrid-test-2"
+        from dotenv import dotenv_values
+        self.index_name = str.lower(dotenv_values(".env").get("PINECONE_INDEX_NAME"))
         self.namespace = "c2si" 
         self.index = self.client.Index(self.index_name)
         


### PR DESCRIPTION
### Summary

Fixes #237  — the README instructs users to create a Pinecone index named `news-index`, but the actual code never reads that name. The read path (`NewsModel.py`) hardcodes a different literal (`cybernews-hybrid-test-2`) than the write path (`db_update/Update.py`, which already reads `PINECONE_INDEX_NAME` from `.env`), so following the README exactly still results in a broken setup — the read and write paths point at two different indexes with no single value a user can set to make them agree.

This PR makes `PINECONE_INDEX_NAME` the single source of truth for both paths, removes an unused hardcoded name, and updates the README to match.

### Changes

**`models/NewsModel.py`** (line 8)
Replaced the hardcoded `self.index_name = "cybernews-hybrid-test-2"` with the same `.env`-driven lookup already used in `db_update/Update.py`:
```python
# Before
self.index_name = "cybernews-hybrid-test-2"

# After
self.index_name = str.lower(dotenv_values(".env").get("PINECONE_INDEX_NAME"))
```
Added `from dotenv import dotenv_values` to support this.

**`config/Database.py`** (line 11)
Removed the unused `index_name = "cybernews-index"` variable. It was never imported anywhere else in the codebase (only `client` is imported from this module), so this is dead-code cleanup with no behavioral impact — but it removes a third, misleading candidate name from the source for anyone trying to figure out the "correct" index name.

**`db_update/Update.py`**
No change — this file was already correct. It's the reference implementation for the `PINECONE_INDEX_NAME` pattern now applied to `NewsModel.py`.

**`README.md`** (line 32)
```markdown
# Before
Login to Pinecone and create a new index with the name `news-index`. Then, add the Pinecone API key in the `.env` file.

# After
Login to Pinecone and create a new index with a name of your choice. Then, add the Pinecone API key and your chosen index name to the `.env` file as `PINECONE_API_KEY` and `PINECONE_INDEX_NAME` respectively (see `.env.example`).
```

### Why

- **Before:** creating `news-index` per the README and setting only `PINECONE_API_KEY` causes `db_update/Update.py` to crash (`PINECONE_INDEX_NAME` is `None`, and `str.lower(None)` raises `TypeError`). Setting `PINECONE_INDEX_NAME=news-index` to work around that lets `db_update/Update.py` populate `news-index` successfully — but `NewsModel.py` still queries `cybernews-hybrid-test-2`, which doesn't exist, so every `/news` and `/news_keywords` request returns empty results.
- **After:** one env var (`PINECONE_INDEX_NAME`) controls both the write path and the read path, and the README no longer hardcodes a name the code doesn't use.

### Scope

This applies to the **root application** (`app.py`, `config/`, `models/`, `db_update/`) — the pre-migration, Pinecone-based path the README's Setup section documents. `api-service/` (used by `docker-compose.yml`) has already moved off Pinecone onto Postgres + pgvector and is unaffected by this change.

### Testing

- [ ] Set `PINECONE_INDEX_NAME` in `.env` to a name of your choice
- [ ] Run `db_update/Update.py` — confirm it creates/populates that index without error
- [ ] Run the app (`flask --app app.py run`) and hit `/mistralai/news` — confirm it now returns data from the same index `db_update/Update.py` populated

### Related

Fixes #237 