### PR TITLE
feat(api-service): add dashboard home page with LLM-powered article Q&A

### DIFF
--- a/api-service/agents/__init__.py
+++ b/api-service/agents/__init__.py
@@ -7,8 +7,11 @@ from agents.responder import responder_agent
 from agents.notification import notification_agent
 
 def _route_after_planner(state: PlannerState) -> str:
-    if state.get("intent") == "subscribe":
+    intent = state.get("intent")
+    if intent == "subscribe":
         return "notification"
+    if intent in ("chitchat", "grounded"):
+        return "responder"
     return "scraper"
 
 def build_graph():
@@ -24,6 +27,7 @@ def build_graph():
     graph.add_conditional_edges("planner", _route_after_planner, {
         "scraper": "scraper",
         "notification": "notification",
+        "responder": "responder",
     })
     graph.add_edge("scraper", "analyzer")
     graph.add_edge("analyzer", "responder")

--- a/api-service/agents/planner.py
+++ b/api-service/agents/planner.py
@@ -1,4 +1,5 @@
 from agents.state import PlannerState
+from services.chat_llm import classify_intent
 
 INTENT_KEYWORDS = {
     "search": ["latest", "news", "what", "show", "find", "get"],
@@ -6,17 +7,40 @@ INTENT_KEYWORDS = {
     "subscribe": ["subscribe", "notify", "alert", "digest"],
 }
 
-def planner_agent(state: PlannerState) -> PlannerState:
-    user_input = state["user_input"].lower()
 
-    intent = "search"  # default
+def _keyword_fallback_intent(user_input: str) -> str:
+    """Word-boundary keyword matching, used when the LLM call fails or is
+    unavailable. Splits on whitespace rather than substring-matching the
+    raw string, so "target" doesn't match "get" or "somewhat" match "what".
+    """
+    words = set(user_input.split())
     for detected_intent, triggers in INTENT_KEYWORDS.items():
-        if any(word in user_input for word in triggers):
-            intent = detected_intent
-            break
+        if words & set(triggers):
+            return detected_intent
+    return "search"
 
-    # Basic keyword extraction — strip common stop words
-    stop_words = {"the", "a", "an", "is", "are", "what", "show", "me", "find", "get", "latest"}
-    keywords = [w for w in user_input.split() if w not in stop_words]
 
-    return {**state, "intent": intent, "keywords": keywords}
+def planner_agent(state: PlannerState) -> PlannerState:
+    raw_input = state["user_input"]
+    user_input = raw_input.lower()
+    active_article = state.get("active_article")
+
+    # force_grounded is set by the route for the exact turn the user clicked
+    # "Ask AI" on a specific article. Grounding only ever applies to this
+    # one turn - the reply includes a real link back to the article instead
+    # of trying to track whether follow-up messages are still on-topic,
+    # since that judgment call proved unreliable across multiple attempts.
+    if state.get("force_grounded") and active_article:
+        return {**state, "intent": "grounded", "keywords": [], "active_article": active_article}
+
+    classified = classify_intent(raw_input)
+
+    if classified:
+        intent = classified["intent"]
+        keywords = classified["keywords"]
+    else:
+        intent = _keyword_fallback_intent(user_input)
+        stop_words = {"the", "a", "an", "is", "are", "what", "show", "me", "find", "get", "latest"}
+        keywords = [w for w in user_input.split() if w not in stop_words]
+
+    return {**state, "intent": intent, "keywords": keywords, "active_article": None}

--- a/api-service/agents/responder.py
+++ b/api-service/agents/responder.py
@@ -3,32 +3,86 @@ import hashlib
 import os
 import redis
 from agents.state import PlannerState
+from services.chat_llm import answer_grounded
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 CACHE_TTL = 300  # 5 minutes
-
 try:
     redis_client = redis.from_url(REDIS_URL, decode_responses=True)
 except Exception:
     redis_client = None
 
-def _cache_key(user_input: str, intent: str) -> str:
-    raw = f"{intent}:{user_input.strip().lower()}"
+
+def _cache_key(raw: str) -> str:
     return "chat:" + hashlib.md5(raw.encode()).hexdigest()
+
+
+def _chitchat_reply(user_input: str) -> str:
+    """Lightweight templated reply for small talk - no LLM call needed for
+    a greeting or thanks, keeps latency low for the common case."""
+    lowered = user_input.lower()
+    if any(w in lowered for w in ("thank", "thanks")):
+        return "you're welcome! let me know if you want to look into anything else."
+    if any(w in lowered for w in ("bye", "goodbye")):
+        return "see you around!"
+    return "hey! ask me about cybersecurity news, or click ask AI on any article to dig into it."
+
 
 def responder_agent(state: PlannerState) -> PlannerState:
     articles = state.get("retrieved_articles", [])
     analysis = state.get("analysis", None)
     user_input = state.get("user_input", "")
     intent = state.get("intent", "search")
+    active_article = state.get("active_article")
 
     if intent == "subscribe":
         message = state.get("notification_message") or "Subscribed successfully."
         response = {"message": message, "articles": []}
         return {**state, "llm_response": json.dumps(response)}
 
-    cache_key = _cache_key(user_input, intent)
+    if intent == "chitchat":
+        response = {"message": _chitchat_reply(user_input), "articles": []}
+        return {**state, "llm_response": json.dumps(response)}
 
+    if intent == "grounded" and active_article:
+        # cache key includes the article id, not just the question text -
+        # "tell me more" means something different per article, caching on
+        # question text alone would leak article A's cached answer to article B
+        cache_key = _cache_key(f"grounded:{active_article.get('id')}:{user_input.strip().lower()}")
+        if redis_client:
+            try:
+                cached = redis_client.get(cache_key)
+                if cached:
+                    return {**state, "llm_response": cached}
+            except Exception:
+                pass
+        answer = answer_grounded(active_article, user_input)
+        if answer:
+            message = answer + "\n\nWant to know more? Click the article below to read the full story."
+        else:
+            message = "I couldn't generate an answer for that, try rephrasing your question."
+        # include the real article as a clickable card - same shape
+        # ScraperAgent normalizes to - so the reply gives an actual link
+        # to read more, instead of trying to guess whether a follow-up
+        # question is still about this article.
+        article_card = {
+            "title": active_article.get("title", "No title"),
+            "source": active_article.get("source_name", "No source"),
+            "date": active_article.get("published_at", "") or "",
+            "url": active_article.get("url", ""),
+            "body": "",
+            "summary": active_article.get("summary"),
+        }
+        response = {"message": message, "articles": [article_card]}
+        result = json.dumps(response)
+        if redis_client:
+            try:
+                redis_client.setex(cache_key, CACHE_TTL, result)
+            except Exception:
+                pass
+        return {**state, "llm_response": result}
+
+    cache_key = _cache_key(f"{intent}:{user_input.strip().lower()}")
     if redis_client:
         try:
             cached = redis_client.get(cache_key)
@@ -41,17 +95,14 @@ def responder_agent(state: PlannerState) -> PlannerState:
         response = {"message": "No articles found for your query.", "articles": []}
     else:
         response = {
-            "message": f"Found {len(articles)} articles.",
+            "message": f"Found {len(articles)} articles. Click any of them below to read the full story.",
             "articles": articles,
             "analysis": analysis,
         }
-
     result = json.dumps(response)
-
     if redis_client:
         try:
             redis_client.setex(cache_key, CACHE_TTL, result)
         except Exception:
             pass
-
     return {**state, "llm_response": result}

--- a/api-service/agents/state.py
+++ b/api-service/agents/state.py
@@ -11,3 +11,5 @@ class PlannerState(TypedDict):
     notification_triggered: bool
     notification_message: Optional[str]
     analysis: Optional[Any]
+    active_article: Optional[dict]
+    force_grounded: Optional[bool]

--- a/api-service/app.py
+++ b/api-service/app.py
@@ -1,10 +1,12 @@
 from dotenv import load_dotenv
 from flask import *
+import logging
 from langchain_classic.prompts import PromptTemplate
 from routes.NewsRoutes import routes
 
 # Load environment variables
 load_dotenv()
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
 
 # `__name__` indicates the unique name of the current module
 app = Flask(__name__)

--- a/api-service/models/NewsModel.py
+++ b/api-service/models/NewsModel.py
@@ -54,6 +54,31 @@ _HYBRID_SELECT = """
 """
 
 
+_TOP_NEWS_SELECT = """
+    SELECT
+        id::text AS id,
+        cve_id,
+        severity AS type,
+        affected_system AS system,
+        to_char(published_at, 'DD-MM-YYYY') AS date
+    FROM articles
+    ORDER BY ingested_at DESC
+    LIMIT %(limit)s
+"""
+
+_CVE_WATCHLIST_SELECT = """
+    SELECT
+        id::text AS id,
+        cve_id,
+        severity,
+        affected_system AS system,
+        to_char(published_at, 'DD-MM-YYYY') AS date
+    FROM articles
+    WHERE cve_id IS NOT NULL
+    ORDER BY published_at DESC
+    LIMIT %(limit)s
+"""
+
 class CybernewsDB:
     def get_news_collections(self, is_keyword=False, keyword=None,
                              search_type="hybrid", alpha=0.3, limit=50,
@@ -98,3 +123,90 @@ class CybernewsDB:
         except Exception as exc:
             logger.error("Failed to fetch articles from Postgres: %s", exc)
             return []
+
+    def get_dashboard_feed(self, filter="newest", source=None, limit=50) -> list[dict]:
+        """Return articles for the dashboard feed. filter must be one of
+        'newest', 'critical', 'frequent' - anything else falls back to
+        newest. source, if given, restricts to that source_name.
+        filter/source never get string-interpolated into SQL directly,
+        filter picks a fixed clause template and source is bound as a param.
+        """
+        where_clauses = []
+        params = {"limit": limit}
+        if filter == "critical":
+            where_clauses.append("severity = 'CRITICAL'")
+        if source:
+            where_clauses.append("source_name = %(source)s")
+            params["source"] = source
+        where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+        if filter == "frequent":
+            order_sql = """ORDER BY (
+                SELECT count(*) FROM articles a2 WHERE a2.source_name = articles.source_name
+            ) DESC, ingested_at DESC"""
+        else:
+            order_sql = "ORDER BY ingested_at DESC"
+        query = f"""
+            SELECT id::text AS id, title, url, summary, source_name,
+                   to_char(ingested_at, 'HH24:MI') AS ingested_time
+            FROM articles
+            {where_sql}
+            {order_sql}
+            LIMIT %(limit)s
+        """
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute(query, params)
+                return cur.fetchall()
+        except Exception as exc:
+            logger.error("Failed to fetch dashboard feed: %s", exc)
+            return []
+
+    def get_distinct_sources(self) -> list[str]:
+        """Return distinct source names currently in the articles table, for
+        the dashboard's source filter dropdown."""
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute("SELECT DISTINCT source_name FROM articles ORDER BY source_name")
+                return [row["source_name"] for row in cur.fetchall()]
+        except Exception as exc:
+            logger.error("Failed to fetch distinct sources: %s", exc)
+            return []
+
+    def get_top_news(self, limit=5) -> list[dict]:
+        """Return the most recent articles for the top news panel, same pool
+        as the feed, not filtered to CVEs."""
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute(_TOP_NEWS_SELECT, {"limit": limit})
+                return cur.fetchall()
+        except Exception as exc:
+            logger.error("Failed to fetch top news: %s", exc)
+            return []
+
+    def get_cve_watchlist(self, limit=5) -> list[dict]:
+        """Return the most recent articles that have a cve_id set. May be
+        sparse - only some articles get cve_id/severity/affected_system
+        populated during ingestion, depending on whether the article
+        content actually references a CVE."""
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute(_CVE_WATCHLIST_SELECT, {"limit": limit})
+                return cur.fetchall()
+        except Exception as exc:
+            logger.error("Failed to fetch cve watchlist: %s", exc)
+            return []
+
+    def get_article_by_id(self, article_id: str) -> dict | None:
+        """Return one article's title, url, content, and summary by id, for
+        pre-loading Chat with article context. None if not found or on
+        a db error."""
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id::text AS id, title, url, content, summary, source_name FROM articles WHERE id = %(id)s",
+                    {"id": article_id},
+                )
+                return cur.fetchone()
+        except Exception as exc:
+            logger.error("Failed to fetch article %s: %s", article_id, exc)
+            return None

--- a/api-service/routes/NewsRoutes.py
+++ b/api-service/routes/NewsRoutes.py
@@ -1,13 +1,16 @@
 from flask import *
+import logging
 from controllers.NewsController import NewsController
 from models.SubscriberModel import SubscriberDB
 from models.SourceModel import SourceDB
+from models.NewsModel import CybernewsDB
 from agents.notification import KNOWN_INTEREST_TAGS
 import json
 import os
 import redis
 
 routes = Blueprint("routes", __name__)
+logger = logging.getLogger(__name__)
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 SESSION_TTL = int(os.getenv("SESSION_TTL", "3600"))
@@ -111,16 +114,33 @@ def health_route():
 """
 chat UI route
 """
+news_db = CybernewsDB()
 @routes.route("/chat", methods=["GET"])
 def chat_ui_route():
-    return render_template("chat.html", active_page="chat")
+    article_id = request.args.get("article_id")
+    article = news_db.get_article_by_id(article_id) if article_id else None
+    return render_template("chat.html", active_page="chat", article=article)
 
 """
-dashboard placeholder route, real dashboard lands week 9
+dashboard - shows the feed, top news panel, and cve watchlist
 """
+DASHBOARD_FILTERS = {"newest", "critical", "frequent"}
 @routes.route("/dashboard", methods=["GET"])
 def dashboard_route():
-    return render_template("coming_soon.html", active_page="home", page_name="Home")
+    filter = request.args.get("filter", "newest")
+    if filter not in DASHBOARD_FILTERS:
+        filter = "newest"
+    source = request.args.get("source") or None
+    return render_template(
+        "dashboard.html",
+        active_page="home",
+        feed=news_db.get_dashboard_feed(filter=filter, source=source),
+        top_news=news_db.get_top_news(),
+        cve_watchlist=news_db.get_cve_watchlist(),
+        sources=news_db.get_distinct_sources(),
+        current_filter=filter,
+        current_source=source or "",
+    )
 
 """
 sources page - GET lists sources, POST adds a new one (pending until
@@ -156,22 +176,27 @@ def chat_route():
     data = request.get_json()
     user_input = data.get("message", "")
     session_id = data.get("session_id", "default")
+    article_id = data.get("article_id")
 
     if not user_input:
         return jsonify({"error": "message is required"}), 400
 
     history = _load_history(session_id)
-
+    # grounding is single-turn: article_id is only present on the exact
+    # request that came from clicking "Ask AI", nothing is persisted across
+    # turns for it, follow-up messages behave like any other chat message
+    active_article = news_db.get_article_by_id(article_id) if article_id else None
+    force_grounded = active_article is not None
     from agents import agent_graph
     result = agent_graph.invoke({
         "user_input": user_input,
         "session_id": session_id,
         "chat_history": history,
         "notification_triggered": False,
+        "active_article": active_article,
+        "force_grounded": force_grounded,
     })
-
     response = result["llm_response"]
-
     history.append({"role": "user", "content": user_input, "intent": result.get("intent")})
     history.append({"role": "assistant", "content": response})
     _save_history(session_id, history[-MAX_HISTORY:])

--- a/api-service/services/chat_llm.py
+++ b/api-service/services/chat_llm.py
@@ -1,0 +1,96 @@
+"""LLM-backed chat understanding.
+Uses the same hosted CohereLabs/tiny-aya-global model (via Hugging Face's
+InferenceClient, provider="cohere") already approved for article
+summarization, for two jobs: classifying a chat message's intent, and
+answering a question grounded on one specific article's real content.
+Both return None on any failure (network, bad JSON, rate limit) so callers
+can fall back to the existing keyword-based logic - this is never a hard
+dependency, same as summarizer.py.
+"""
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+HF_TOKEN = os.getenv("HUGGINGFACE_TOKEN")
+COHERE_MODEL = "CohereLabs/tiny-aya-global"
+MAX_INPUT_CHARS = 2000
+
+VALID_INTENTS = {"search", "analyze", "subscribe", "chitchat"}
+
+_INTENT_PROMPT = """Classify this chat message for a cybersecurity news assistant.
+Return ONLY a JSON object, no other text, in this exact shape:
+{{"intent": "search"|"analyze"|"subscribe"|"chitchat", "keywords": ["..."]}}
+
+- "search": user wants to find or read about cybersecurity news/topics
+- "analyze": user wants trends, sentiment, or stats about articles
+- "subscribe": user wants to sign up for email alerts/digests
+- "chitchat": greetings, thanks, small talk, anything with no real search intent
+- "keywords": meaningful search terms only, empty list if not a search
+
+Message: {message}"""
+
+_GROUNDED_PROMPT = """Answer the user's question using ONLY the article content below.
+Do not invent facts, dates, or details not present in the article. If the
+article doesn't contain the answer, say so plainly.
+
+Article title: {title}
+Article source: {source}
+Article content: {content}
+
+Question: {question}"""
+
+
+def _client():
+    from huggingface_hub import InferenceClient
+    return InferenceClient(provider="cohere", token=HF_TOKEN)
+
+
+def classify_intent(user_input: str) -> dict | None:
+    """Return {"intent", "keywords"} or None on failure."""
+    if not HF_TOKEN or not user_input or not user_input.strip():
+        return None
+    try:
+        completion = _client().chat.completions.create(
+            model=COHERE_MODEL,
+            messages=[{
+                "role": "user",
+                "content": _INTENT_PROMPT.format(message=user_input),
+            }],
+        )
+        raw = completion.choices[0].message.content.strip()
+        raw = raw.removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+        parsed = json.loads(raw)
+        if parsed.get("intent") not in VALID_INTENTS:
+            return None
+        return {
+            "intent": parsed["intent"],
+            "keywords": parsed.get("keywords") or [],
+        }
+    except Exception:
+        logger.exception("intent classification failed, falling back to keyword matching")
+        return None
+
+
+def answer_grounded(article: dict, question: str) -> str | None:
+    """Answer a question using only the given article's content. None on failure."""
+    if not HF_TOKEN or not article or not question:
+        return None
+    try:
+        completion = _client().chat.completions.create(
+            model=COHERE_MODEL,
+            messages=[{
+                "role": "user",
+                "content": _GROUNDED_PROMPT.format(
+                    title=article.get("title", ""),
+                    source=article.get("source_name", ""),
+                    content=(article.get("content") or article.get("summary") or "")[:MAX_INPUT_CHARS],
+                    question=question,
+                ),
+            }],
+        )
+        return completion.choices[0].message.content.strip()
+    except Exception:
+        logger.exception("grounded answer generation failed")
+        return None

--- a/api-service/templates/chat.html
+++ b/api-service/templates/chat.html
@@ -254,6 +254,7 @@
         thread.scrollTop = thread.scrollHeight;
     }
 
+    let pendingArticleId = {{ (article.id if article else None)|tojson }};
     async function sendMessage() {
         const text = input.value.trim();
         if (!text) return;
@@ -261,12 +262,17 @@
         input.value = '';
         btn.disabled = true;
         appendUserMessage(text);
+        const payload = { message: text, session_id: sessionId };
+        if (pendingArticleId) {
+            payload.article_id = pendingArticleId;
+            pendingArticleId = null;
+        }
 
         try {
             const res = await fetch('/chat', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ message: text, session_id: sessionId })
+                body: JSON.stringify(payload)
             });
             const data = await res.json();
             appendBotResponse(data.response);
@@ -282,5 +288,9 @@
     input.addEventListener('keydown', function (e) {
         if (e.key === 'Enter') sendMessage();
     });
+    {% if article %}
+    input.value = 'tell me about this article: ' + {{ article.title|tojson }};
+    sendMessage();
+    {% endif %}
 </script>
 {% endblock %}

--- a/api-service/templates/dashboard.html
+++ b/api-service/templates/dashboard.html
@@ -1,0 +1,189 @@
+{% extends "base.html" %}
+{% block title %}Home{% endblock %}
+{% block extra_style %}
+#dashboard-container {
+    max-width: 1000px;
+    margin: 48px auto;
+    padding: 32px;
+}
+#dashboard-container h1 {
+    font-family: var(--font-heading);
+    font-size: 1.6em;
+    margin-bottom: 24px;
+}
+.panel-row {
+    display: flex;
+    gap: 24px;
+    margin-bottom: 32px;
+}
+.panel {
+    flex: 1;
+    min-width: 0;
+}
+.panel h2 {
+    font-size: 1em;
+    color: var(--color-text-muted-dark);
+    margin-bottom: 12px;
+}
+.panel table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.panel th {
+    text-align: left;
+    font-size: 0.8em;
+    color: var(--color-text-muted-dark);
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--color-border-dark);
+}
+.panel td {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--color-border-dark);
+    font-size: 0.85em;
+}
+.panel .empty-row td {
+    color: var(--color-text-muted-dark);
+    font-style: italic;
+}
+.severity-badge {
+    font-size: 0.75em;
+    padding: 2px 8px;
+    border-radius: 10px;
+}
+.severity-critical { background: rgba(255, 70, 70, 0.15); color: #ff4646; }
+.severity-high { background: rgba(255, 170, 0, 0.15); color: #ffaa00; }
+.severity-medium { background: rgba(255, 220, 0, 0.15); color: #ffdc00; }
+.severity-low { background: rgba(60, 180, 100, 0.15); color: #3cb464; }
+#filter-controls {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--color-border-dark);
+}
+.filter-tab {
+    color: var(--color-text-muted-dark);
+    text-decoration: none;
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 0.9em;
+}
+.filter-tab.active {
+    background: var(--color-primary);
+    color: #fff;
+}
+#source-select {
+    margin-left: auto;
+    padding: 6px 10px;
+    background: var(--color-surface-dark);
+    border: 1px solid var(--color-border-dark);
+    border-radius: 6px;
+    color: var(--color-text-dark);
+    font-family: var(--font-body);
+}
+.feed-item {
+    padding: 16px 0;
+    border-bottom: 1px solid var(--color-border-dark);
+}
+.feed-item .feed-meta {
+    font-size: 0.8em;
+    color: var(--color-text-muted-dark);
+    margin-bottom: 4px;
+}
+.feed-item a {
+    color: var(--color-text-dark);
+    font-weight: 600;
+    text-decoration: none;
+}
+.feed-item p {
+    margin: 6px 0 8px;
+    font-size: 0.9em;
+    color: var(--color-text-muted-dark);
+}
+.ask-ai-btn {
+    background: var(--color-primary);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 14px;
+    font-size: 0.8em;
+    cursor: pointer;
+    font-family: var(--font-body);
+    text-decoration: none;
+    display: inline-block;
+}
+{% endblock %}
+{% block content %}
+<div id="dashboard-container">
+    <h1>Home</h1>
+
+    <div class="panel-row">
+        <div class="panel">
+            <h2>CVE Watchlist</h2>
+            <table>
+                <thead>
+                    <tr><th>CVE-ID</th><th>Severity</th><th>System</th><th>Date</th></tr>
+                </thead>
+                <tbody>
+                    {% for c in cve_watchlist %}
+                    <tr>
+                        <td><a href="{{ url_for('routes.chat_ui_route') }}?article_id={{ c.id }}">{{ c.cve_id }}</a></td>
+                        {% if c.severity %}<td><span class="severity-badge severity-{{ c.severity|lower }}">{{ c.severity }}</span></td>{% else %}<td>—</td>{% endif %}
+                        <td>{{ c.system or "—" }}</td>
+                        <td>{{ c.date or "—" }}</td>
+                    </tr>
+                    {% else %}
+                    <tr class="empty-row"><td colspan="4">no CVEs tagged yet</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <div class="panel">
+            <h2>Top News</h2>
+            <table>
+                <thead>
+                    <tr><th>CVE-ID</th><th>Type</th><th>System</th><th>Date</th></tr>
+                </thead>
+                <tbody>
+                    {% for n in top_news %}
+                    <tr>
+                        <td>{{ n.cve_id or "—" }}</td>
+                        <td>{% if n.type %}<span class="severity-badge severity-{{ n.type|lower }}">{{ n.type }}</span>{% else %}—{% endif %}</td>
+                        <td>{{ n.system or "—" }}</td>
+                        <td>{{ n.date or "—" }}</td>
+                    </tr>
+                    {% else %}
+                    <tr class="empty-row"><td colspan="4">no articles yet</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div id="filter-controls">
+        <a href="?filter=newest{% if current_source %}&source={{ current_source|urlencode }}{% endif %}" class="filter-tab{% if current_filter == 'newest' %} active{% endif %}">Newest</a>
+        <a href="?filter=critical{% if current_source %}&source={{ current_source|urlencode }}{% endif %}" class="filter-tab{% if current_filter == 'critical' %} active{% endif %}">Critical</a>
+        <a href="?filter=frequent{% if current_source %}&source={{ current_source|urlencode }}{% endif %}" class="filter-tab{% if current_filter == 'frequent' %} active{% endif %}">Frequent</a>
+        <select id="source-select" onchange="window.location.href='?filter={{ current_filter }}' + (this.value ? '&source=' + encodeURIComponent(this.value) : '')">
+            <option value="">All sources</option>
+            {% for s in sources %}
+            <option value="{{ s }}" {% if s == current_source %}selected{% endif %}>{{ s }}</option>
+            {% endfor %}
+        </select>
+    </div>
+
+    <div id="feed">
+        {% for item in feed %}
+        <div class="feed-item">
+            <div class="feed-meta">{{ item.ingested_time }} &middot; {{ item.source_name }}</div>
+            <a href="{{ item.url }}" target="_blank">{{ item.title }}</a>
+            <p>{{ item.summary or "no summary yet" }}</p>
+            <a class="ask-ai-btn" href="{{ url_for('routes.chat_ui_route') }}?article_id={{ item.id }}">Ask AI</a>
+        </div>
+        {% else %}
+        <p>no articles yet.</p>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/api-service/tests/test_chat_get_route.py
+++ b/api-service/tests/test_chat_get_route.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock
+
+
+def _client():
+    from app import app
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+class TestChatGetRoute:
+    def test_renders_without_article_id(self, mocker):
+        client = _client()
+        response = client.get("/chat")
+        assert response.status_code == 200
+        assert b"pendingArticleId = null;" in response.data
+
+    def test_renders_with_article_context_when_article_id_given(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.get_article_by_id.return_value = {
+            "id": "1", "title": "Critical RCE Found", "url": "https://x.com",
+            "summary": "s", "source_name": "Krebs",
+        }
+        mocker.patch.object(NewsRoutes, "news_db", mock_db)
+        client = _client()
+        response = client.get("/chat?article_id=1")
+        assert response.status_code == 200
+        assert b"Critical RCE Found" in response.data
+        mock_db.get_article_by_id.assert_called_once_with("1")
+
+    def test_unknown_article_id_renders_normally(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.get_article_by_id.return_value = None
+        mocker.patch.object(NewsRoutes, "news_db", mock_db)
+        client = _client()
+        response = client.get("/chat?article_id=nonexistent")
+        assert response.status_code == 200
+        assert b"pendingArticleId = null;" in response.data
+
+    def test_apostrophe_in_title_escaped_safely(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.get_article_by_id.return_value = {
+            "id": "1", "title": "Hacker's New Toolkit Exposed", "url": "https://x.com",
+            "summary": "s", "source_name": "Krebs",
+        }
+        mocker.patch.object(NewsRoutes, "news_db", mock_db)
+        client = _client()
+        response = client.get("/chat?article_id=1")
+        body = response.get_data(as_text=True)
+        assert "\\u0027" in body
+        assert "\\\\'" not in body

--- a/api-service/tests/test_chat_llm.py
+++ b/api-service/tests/test_chat_llm.py
@@ -1,0 +1,163 @@
+from unittest.mock import MagicMock
+
+
+def _mock_response(content):
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = content
+    return mock_response
+
+
+class TestClassifyIntent:
+    def test_no_token_returns_none_without_calling_client(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", None)
+        result = chat_llm.classify_intent("hi")
+        assert result is None
+
+    def test_empty_input_returns_none(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        result = chat_llm.classify_intent("   ")
+        assert result is None
+
+    def test_valid_json_response_parsed(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _mock_response(
+            '{"intent": "search", "keywords": ["ransomware"]}'
+        )
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = chat_llm.classify_intent("show me ransomware news")
+        assert result == {"intent": "search", "keywords": ["ransomware"]}
+
+    def test_markdown_fenced_json_stripped(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _mock_response(
+            '```json\n{"intent": "chitchat", "keywords": []}\n```'
+        )
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = chat_llm.classify_intent("hi")
+        assert result["intent"] == "chitchat"
+
+    def test_invalid_intent_value_returns_none(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _mock_response(
+            '{"intent": "made_up_intent", "keywords": []}'
+        )
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = chat_llm.classify_intent("hi")
+        assert result is None
+
+    def test_malformed_json_returns_none_instead_of_raising(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _mock_response("not json at all")
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = chat_llm.classify_intent("hi")
+        assert result is None
+
+    def test_exception_returns_none_instead_of_raising(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = Exception("cohere is down")
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = chat_llm.classify_intent("hi")
+        assert result is None
+
+    def test_missing_optional_fields_default_safely(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _mock_response('{"intent": "chitchat"}')
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = chat_llm.classify_intent("hi")
+        assert result == {"intent": "chitchat", "keywords": []}
+
+
+class TestAnswerGrounded:
+    def test_no_token_returns_none(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", None)
+        result = chat_llm.answer_grounded({"title": "t"}, "what happened?")
+        assert result is None
+
+    def test_no_article_returns_none(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        result = chat_llm.answer_grounded(None, "what happened?")
+        assert result is None
+
+    def test_successful_answer_returned(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _mock_response("  the article describes a critical RCE  ")
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = chat_llm.answer_grounded(
+            {"title": "Critical RCE Found", "source_name": "Krebs", "summary": "a summary"},
+            "what happened?",
+        )
+        assert result == "the article describes a critical RCE"
+
+    def test_prefers_content_over_summary(self, mocker):
+        """Regression test: grounding must use the article's real content
+        when present, not the short LLM-generated summary."""
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _mock_response("answer")
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        chat_llm.answer_grounded(
+            {"title": "t", "source_name": "s", "content": "the real full article body", "summary": "a short summary"},
+            "what happened?",
+        )
+        prompt = mock_client.chat.completions.create.call_args[1]["messages"][0]["content"]
+        assert "the real full article body" in prompt
+        assert "a short summary" not in prompt
+
+    def test_falls_back_to_summary_when_content_missing(self, mocker):
+        """If content hasn't been backfilled/ingested yet, fall back to
+        summary rather than sending an empty string to the prompt."""
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _mock_response("answer")
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        chat_llm.answer_grounded(
+            {"title": "t", "source_name": "s", "summary": "a short summary"},
+            "what happened?",
+        )
+        prompt = mock_client.chat.completions.create.call_args[1]["messages"][0]["content"]
+        assert "a short summary" in prompt
+
+    def test_content_truncated_to_max_input_chars(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _mock_response("answer")
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        long_content = "x" * (chat_llm.MAX_INPUT_CHARS + 500)
+        chat_llm.answer_grounded(
+            {"title": "t", "source_name": "s", "content": long_content},
+            "what happened?",
+        )
+        prompt = mock_client.chat.completions.create.call_args[1]["messages"][0]["content"]
+        assert "x" * chat_llm.MAX_INPUT_CHARS in prompt
+        assert "x" * (chat_llm.MAX_INPUT_CHARS + 1) not in prompt
+
+    def test_exception_returns_none_instead_of_raising(self, mocker):
+        from services import chat_llm
+        mocker.patch.object(chat_llm, "HF_TOKEN", "fake-token")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = Exception("cohere is down")
+        mocker.patch("huggingface_hub.InferenceClient", return_value=mock_client)
+        result = chat_llm.answer_grounded({"title": "t"}, "what happened?")
+        assert result is None
+

--- a/api-service/tests/test_chat_post_route.py
+++ b/api-service/tests/test_chat_post_route.py
@@ -1,0 +1,63 @@
+import json
+from unittest.mock import MagicMock
+
+
+def _client():
+    from app import app
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+class TestChatPostRoute:
+    def test_missing_message_returns_400(self, mocker):
+        client = _client()
+        response = client.post("/chat", json={"session_id": "s1"})
+        assert response.status_code == 400
+
+    def test_article_id_in_payload_fetches_and_force_grounds(self, mocker):
+        from routes import NewsRoutes
+        mock_news_db = MagicMock()
+        article = {"id": "1", "title": "Critical RCE Found", "summary": "s", "source_name": "Krebs"}
+        mock_news_db.get_article_by_id.return_value = article
+        mocker.patch.object(NewsRoutes, "news_db", mock_news_db)
+
+        mock_graph = MagicMock()
+        mock_graph.invoke.return_value = {
+            "llm_response": json.dumps({"message": "answer", "articles": []}),
+            "intent": "grounded",
+        }
+        mocker.patch("agents.agent_graph", mock_graph)
+
+        client = _client()
+        response = client.post("/chat", json={
+            "message": "tell me about this article: Critical RCE Found",
+            "session_id": "s1",
+            "article_id": "1",
+        })
+        assert response.status_code == 200
+        mock_news_db.get_article_by_id.assert_called_once_with("1")
+        invoke_kwargs = mock_graph.invoke.call_args[0][0]
+        assert invoke_kwargs["active_article"] == article
+        assert invoke_kwargs["force_grounded"] is True
+
+    def test_no_article_id_never_grounds(self, mocker):
+        """Grounding is single-turn only - a plain follow-up message with no
+        article_id in the payload never grounds, regardless of prior turns."""
+        from routes import NewsRoutes
+        mock_news_db = MagicMock()
+        mocker.patch.object(NewsRoutes, "news_db", mock_news_db)
+
+        mock_graph = MagicMock()
+        mock_graph.invoke.return_value = {
+            "llm_response": json.dumps({"message": "answer", "articles": [{"headlines": "x"}]}),
+            "intent": "search",
+        }
+        mocker.patch("agents.agent_graph", mock_graph)
+
+        client = _client()
+        response = client.post("/chat", json={"message": "tell me more", "session_id": "s1"})
+        assert response.status_code == 200
+        mock_news_db.get_article_by_id.assert_not_called()
+        invoke_kwargs = mock_graph.invoke.call_args[0][0]
+        assert invoke_kwargs["active_article"] is None
+        assert invoke_kwargs["force_grounded"] is False

--- a/api-service/tests/test_dashboard_routes.py
+++ b/api-service/tests/test_dashboard_routes.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock
+
+
+def _client():
+    from app import app
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+class TestDashboardRoute:
+    def test_renders_with_default_newest_filter(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.get_dashboard_feed.return_value = []
+        mock_db.get_top_news.return_value = []
+        mock_db.get_cve_watchlist.return_value = []
+        mock_db.get_distinct_sources.return_value = []
+        mocker.patch.object(NewsRoutes, "news_db", mock_db)
+        client = _client()
+        response = client.get("/dashboard")
+        assert response.status_code == 200
+        mock_db.get_dashboard_feed.assert_called_once_with(filter="newest", source=None)
+
+    def test_invalid_filter_falls_back_to_newest(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.get_dashboard_feed.return_value = []
+        mock_db.get_top_news.return_value = []
+        mock_db.get_cve_watchlist.return_value = []
+        mock_db.get_distinct_sources.return_value = []
+        mocker.patch.object(NewsRoutes, "news_db", mock_db)
+        client = _client()
+        response = client.get("/dashboard?filter=' OR 1=1--")
+        assert response.status_code == 200
+        mock_db.get_dashboard_feed.assert_called_once_with(filter="newest", source=None)
+
+    def test_valid_filter_and_source_passed_through(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.get_dashboard_feed.return_value = []
+        mock_db.get_top_news.return_value = []
+        mock_db.get_cve_watchlist.return_value = []
+        mock_db.get_distinct_sources.return_value = []
+        mocker.patch.object(NewsRoutes, "news_db", mock_db)
+        client = _client()
+        response = client.get("/dashboard?filter=critical&source=Krebs")
+        assert response.status_code == 200
+        mock_db.get_dashboard_feed.assert_called_once_with(filter="critical", source="Krebs")
+
+    def test_feed_content_rendered(self, mocker):
+        from routes import NewsRoutes
+        mock_db = MagicMock()
+        mock_db.get_dashboard_feed.return_value = [
+            {"id": "1", "title": "Test Article", "url": "https://x.com", "summary": "a summary", "source_name": "Krebs", "ingested_time": "10:30"}
+        ]
+        mock_db.get_top_news.return_value = []
+        mock_db.get_cve_watchlist.return_value = []
+        mock_db.get_distinct_sources.return_value = []
+        mocker.patch.object(NewsRoutes, "news_db", mock_db)
+        client = _client()
+        response = client.get("/dashboard")
+        assert response.status_code == 200
+        assert b"Test Article" in response.data

--- a/api-service/tests/test_graph_routing.py
+++ b/api-service/tests/test_graph_routing.py
@@ -43,3 +43,50 @@ class TestGraphRouting:
         assert result["intent"] == "subscribe"
         assert result["notification_triggered"] is True
         mock_db.get_news_collections.assert_not_called()
+
+    def test_chitchat_intent_skips_scraper(self, mocker):
+        from agents import planner as planner_module
+        from agents import scraper as scraper_module
+        from agents import responder as responder_module
+        mocker.patch.object(planner_module, "classify_intent", return_value={
+            "intent": "chitchat", "keywords": [],
+        })
+        mock_db = MagicMock()
+        mocker.patch.object(scraper_module, "db", mock_db)
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mocker.patch.object(responder_module, "redis_client", mock_redis)
+        from agents import agent_graph
+        result = agent_graph.invoke({
+            "user_input": "hi",
+            "session_id": "test",
+            "chat_history": [],
+            "notification_triggered": False,
+            "active_article": None,
+        })
+        assert result["intent"] == "chitchat"
+        mock_db.get_news_collections.assert_not_called()
+
+    def test_grounded_intent_skips_scraper(self, mocker):
+        from agents import planner as planner_module
+        from agents import scraper as scraper_module
+        from agents import responder as responder_module
+        classify_spy = mocker.patch.object(planner_module, "classify_intent")
+        mock_db = MagicMock()
+        mocker.patch.object(scraper_module, "db", mock_db)
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mocker.patch.object(responder_module, "redis_client", mock_redis)
+        mocker.patch.object(responder_module, "answer_grounded", return_value="a real answer")
+        from agents import agent_graph
+        result = agent_graph.invoke({
+            "user_input": "tell me about this article",
+            "session_id": "test",
+            "chat_history": [],
+            "notification_triggered": False,
+            "active_article": {"id": "1", "title": "Critical RCE Found", "summary": "s", "source_name": "Krebs"},
+            "force_grounded": True,
+        })
+        assert result["intent"] == "grounded"
+        mock_db.get_news_collections.assert_not_called()
+        classify_spy.assert_not_called()

--- a/api-service/tests/test_news_model.py
+++ b/api-service/tests/test_news_model.py
@@ -91,3 +91,172 @@ class TestCybernewsDB:
         db.get_news_collections(limit=10)
 
         mock_register.assert_called_once()
+
+
+class TestGetDashboardFeed:
+    def test_default_newest_order(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [{"id": "1", "title": "t"}]
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        result = db.get_dashboard_feed()
+        assert result == [{"id": "1", "title": "t"}]
+        sql, params = mock_cur.execute.call_args[0]
+        assert "WHERE" not in sql
+        assert "ORDER BY ingested_at DESC" in sql
+        assert params == {"limit": 50}
+
+    def test_critical_filter_adds_where_clause(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        db.get_dashboard_feed(filter="critical")
+        sql, params = mock_cur.execute.call_args[0]
+        assert "severity = 'CRITICAL'" in sql
+
+    def test_source_filter_binds_as_param_not_interpolated(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        db.get_dashboard_feed(source="Krebs; DROP TABLE articles;")
+        sql, params = mock_cur.execute.call_args[0]
+        assert "source_name = %(source)s" in sql
+        assert params["source"] == "Krebs; DROP TABLE articles;"
+        assert "DROP TABLE" not in sql
+
+    def test_frequent_filter_orders_by_source_count(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        db.get_dashboard_feed(filter="frequent")
+        sql, params = mock_cur.execute.call_args[0]
+        assert "count(*)" in sql
+
+    def test_returns_empty_list_on_db_error(self, mocker):
+        from models import NewsModel
+        mocker.patch.object(NewsModel, "get_connection", side_effect=Exception("db down"))
+        db = NewsModel.CybernewsDB()
+        result = db.get_dashboard_feed()
+        assert result == []
+
+
+class TestGetDistinctSources:
+    def test_returns_source_names(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [{"source_name": "Krebs"}, {"source_name": "SANS"}]
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        result = db.get_distinct_sources()
+        assert result == ["Krebs", "SANS"]
+
+    def test_returns_empty_list_on_db_error(self, mocker):
+        from models import NewsModel
+        mocker.patch.object(NewsModel, "get_connection", side_effect=Exception("db down"))
+        db = NewsModel.CybernewsDB()
+        result = db.get_distinct_sources()
+        assert result == []
+
+
+class TestGetCveWatchlist:
+    def test_filters_to_articles_with_cve_id(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        db.get_cve_watchlist()
+        sql, params = mock_cur.execute.call_args[0]
+        assert "cve_id IS NOT NULL" in sql
+
+    def test_returns_empty_list_on_db_error(self, mocker):
+        from models import NewsModel
+        mocker.patch.object(NewsModel, "get_connection", side_effect=Exception("db down"))
+        db = NewsModel.CybernewsDB()
+        result = db.get_cve_watchlist()
+        assert result == []
+
+
+class TestGetArticleById:
+    def test_returns_article_row(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = {"id": "1", "title": "t"}
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        result = db.get_article_by_id("1")
+        assert result == {"id": "1", "title": "t"}
+
+    def test_returns_none_on_db_error(self, mocker):
+        from models import NewsModel
+        mocker.patch.object(NewsModel, "get_connection", side_effect=Exception("db down"))
+        db = NewsModel.CybernewsDB()
+        result = db.get_article_by_id("1")
+        assert result is None
+
+    def test_selects_content_column(self, mocker):
+        """Regression test: get_article_by_id must select content, not just
+        summary, so Ask AI can ground answers on the real article body
+        instead of silently falling back to the short summary."""
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = None
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        db.get_article_by_id("1")
+        sql, params = mock_cur.execute.call_args[0]
+        assert "content" in sql
+
+
+class TestArticleIdCastToText:
+    """Regression test: article id must be cast to text in every query that
+    selects it. Without this cast, psycopg returns a uuid.UUID object, which
+    isn't JSON-serializable - and since session storage silently swallowed
+    that failure, article grounding broke without any visible error."""
+
+    def test_dashboard_feed_casts_id_to_text(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        db.get_dashboard_feed()
+        sql, params = mock_cur.execute.call_args[0]
+        assert "id::text AS id" in sql
+
+    def test_top_news_casts_id_to_text(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        db.get_top_news()
+        sql, params = mock_cur.execute.call_args[0]
+        assert "id::text AS id" in sql
+
+    def test_cve_watchlist_casts_id_to_text(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        db.get_cve_watchlist()
+        sql, params = mock_cur.execute.call_args[0]
+        assert "id::text AS id" in sql
+
+    def test_get_article_by_id_casts_id_to_text(self, mocker):
+        from models import NewsModel
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchone.return_value = None
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        db = NewsModel.CybernewsDB()
+        db.get_article_by_id("1")
+        sql, params = mock_cur.execute.call_args[0]
+        assert "id::text AS id" in sql

--- a/api-service/tests/test_planner.py
+++ b/api-service/tests/test_planner.py
@@ -13,48 +13,123 @@ def make_state(**kwargs):
         "chat_history": [],
         "notification_triggered": False,
         "analysis": None,
+        "active_article": None,
     }
     base.update(kwargs)
     return base
 
 
-class TestPlannerAgent:
-    def test_search_intent(self):
-        from agents.planner import planner_agent
+class TestPlannerAgentKeywordFallback:
+    """LLM call mocked to return None (unavailable/failed) - tests the
+    existing keyword-matching fallback path deterministically, regardless
+    of whether HF_TOKEN happens to be set in the environment."""
+
+    def test_search_intent(self, mocker):
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value=None)
         state = make_state(user_input="show me latest ransomware news")
-        result = planner_agent(state)
+        result = planner.planner_agent(state)
         assert result["intent"] == "search"
 
-    def test_analyze_intent(self):
-        from agents.planner import planner_agent
+    def test_analyze_intent(self, mocker):
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value=None)
         state = make_state(user_input="analyze trends in malware attacks")
-        result = planner_agent(state)
+        result = planner.planner_agent(state)
         assert result["intent"] == "analyze"
 
-    def test_subscribe_intent(self):
-        from agents.planner import planner_agent
+    def test_subscribe_intent(self, mocker):
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value=None)
         state = make_state(user_input="subscribe me to daily digest")
-        result = planner_agent(state)
+        result = planner.planner_agent(state)
         assert result["intent"] == "subscribe"
 
-    def test_default_intent_is_search(self):
-        from agents.planner import planner_agent
+    def test_default_intent_is_search(self, mocker):
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value=None)
         state = make_state(user_input="ransomware")
-        result = planner_agent(state)
+        result = planner.planner_agent(state)
         assert result["intent"] == "search"
 
-    def test_stop_words_stripped_from_keywords(self):
-        from agents.planner import planner_agent
+    def test_stop_words_stripped_from_keywords(self, mocker):
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value=None)
         state = make_state(user_input="show me the latest ransomware news")
-        result = planner_agent(state)
+        result = planner.planner_agent(state)
         assert "show" not in result["keywords"]
         assert "the" not in result["keywords"]
         assert "latest" not in result["keywords"]
         assert "ransomware" in result["keywords"]
 
-    def test_keywords_extracted(self):
-        from agents.planner import planner_agent
+    def test_keywords_extracted(self, mocker):
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value=None)
         state = make_state(user_input="find ransomware attacks")
-        result = planner_agent(state)
+        result = planner.planner_agent(state)
         assert "ransomware" in result["keywords"]
         assert "attacks" in result["keywords"]
+
+    def test_word_boundary_matching_not_substring(self, mocker):
+        """'target' shouldn't match the 'get' keyword trigger via substring."""
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value=None)
+        state = make_state(user_input="target systems affected")
+        result = planner.planner_agent(state)
+        assert result["intent"] == "search"  # falls to default, not a false subscribe/analyze match
+
+    def test_non_force_grounded_turn_never_stays_grounded(self, mocker):
+        """Grounding is single-turn only - any turn that isn't the exact
+        force_grounded turn always clears active_article, regardless of
+        what the LLM (or its absence) returns."""
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value=None)
+        state = make_state(user_input="tell me more", active_article={"id": "1", "title": "t"})
+        result = planner.planner_agent(state)
+        assert result["active_article"] is None
+
+
+class TestPlannerAgentLlmClassification:
+    def test_llm_intent_used_when_available(self, mocker):
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value={
+            "intent": "chitchat", "keywords": [],
+        })
+        state = make_state(user_input="hi")
+        result = planner.planner_agent(state)
+        assert result["intent"] == "chitchat"
+
+
+class TestPlannerAgentForceGrounded:
+    def test_force_grounded_skips_llm_call_entirely(self, mocker):
+        from agents import planner
+        classify_spy = mocker.patch.object(planner, "classify_intent")
+        article = {"id": "1", "title": "Critical RCE Found"}
+        state = make_state(
+            user_input="tell me about this article: Critical RCE Found",
+            active_article=article,
+            force_grounded=True,
+        )
+        result = planner.planner_agent(state)
+        assert result["intent"] == "grounded"
+        assert result["active_article"] == article
+        classify_spy.assert_not_called()
+
+    def test_force_grounded_without_active_article_falls_through_normally(self, mocker):
+        from agents import planner
+        mocker.patch.object(planner, "classify_intent", return_value=None)
+        state = make_state(user_input="hello", active_article=None, force_grounded=True)
+        result = planner.planner_agent(state)
+        assert result["intent"] == "search"
+
+    def test_not_force_grounded_still_asks_llm_normally(self, mocker):
+        from agents import planner
+        classify_spy = mocker.patch.object(planner, "classify_intent", return_value={
+            "intent": "search", "keywords": ["phishing"],
+        })
+        article = {"id": "1", "title": "t"}
+        state = make_state(user_input="find me phishing news", active_article=article, force_grounded=False)
+        result = planner.planner_agent(state)
+        assert result["intent"] == "search"
+        assert result["active_article"] is None
+        classify_spy.assert_called_once()

--- a/api-service/tests/test_responder.py
+++ b/api-service/tests/test_responder.py
@@ -91,3 +91,100 @@ class TestResponderAgent:
         state = make_state(intent="search", user_input="ransomware", retrieved_articles=SAMPLE_ARTICLES)
         result = responder_agent(state)
         assert result["llm_response"] is not None
+
+
+class TestResponderAgentChitchat:
+    def test_chitchat_returns_templated_reply_no_llm_call(self, mocker):
+        from agents import responder as responder_module
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mocker.patch.object(responder_module, "redis_client", mock_redis)
+        answer_grounded_spy = mocker.patch.object(responder_module, "answer_grounded")
+        from agents.responder import responder_agent
+        state = make_state(user_input="hi", intent="chitchat")
+        result = responder_agent(state)
+        response = json.loads(result["llm_response"])
+        assert response["articles"] == []
+        assert "message" in response
+        answer_grounded_spy.assert_not_called()
+
+    def test_thanks_gets_thanks_reply(self, mocker):
+        from agents import responder as responder_module
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mocker.patch.object(responder_module, "redis_client", mock_redis)
+        from agents.responder import responder_agent
+        state = make_state(user_input="thanks!", intent="chitchat")
+        result = responder_agent(state)
+        response = json.loads(result["llm_response"])
+        assert "welcome" in response["message"].lower()
+
+
+class TestResponderAgentGrounded:
+    def test_grounded_calls_answer_grounded_with_active_article(self, mocker):
+        from agents import responder as responder_module
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mocker.patch.object(responder_module, "redis_client", mock_redis)
+        mocker.patch.object(responder_module, "answer_grounded", return_value="the RCE affects Apache servers")
+        from agents.responder import responder_agent
+        article = {"id": "1", "title": "Critical RCE Found", "summary": "s", "source_name": "Krebs"}
+        state = make_state(user_input="what's affected?", intent="grounded", active_article=article)
+        result = responder_agent(state)
+        response = json.loads(result["llm_response"])
+        assert response["message"] == "the RCE affects Apache servers\n\nWant to know more? Click the article below to read the full story."
+        responder_module.answer_grounded.assert_called_once_with(article, "what's affected?")
+
+    def test_grounded_response_includes_real_article_card(self, mocker):
+        """The grounded reply includes an actual clickable link to the
+        article, in the same shape ScraperAgent normalizes articles to, so
+        the existing frontend rendering picks it up with no new JS needed."""
+        from agents import responder as responder_module
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mocker.patch.object(responder_module, "redis_client", mock_redis)
+        mocker.patch.object(responder_module, "answer_grounded", return_value="an answer")
+        from agents.responder import responder_agent
+        article = {
+            "id": "1", "title": "Critical RCE Found", "summary": "a summary",
+            "source_name": "Krebs", "url": "https://example.com/rce",
+        }
+        state = make_state(user_input="what happened?", intent="grounded", active_article=article)
+        result = responder_agent(state)
+        response = json.loads(result["llm_response"])
+        assert len(response["articles"]) == 1
+        card = response["articles"][0]
+        assert card["title"] == "Critical RCE Found"
+        assert card["url"] == "https://example.com/rce"
+        assert card["source"] == "Krebs"
+        assert card["summary"] == "a summary"
+
+    def test_grounded_answer_failure_returns_fallback_message(self, mocker):
+        from agents import responder as responder_module
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mocker.patch.object(responder_module, "redis_client", mock_redis)
+        mocker.patch.object(responder_module, "answer_grounded", return_value=None)
+        from agents.responder import responder_agent
+        article = {"id": "1", "title": "t"}
+        state = make_state(user_input="what's affected?", intent="grounded", active_article=article)
+        result = responder_agent(state)
+        response = json.loads(result["llm_response"])
+        assert "couldn't" in response["message"].lower()
+
+    def test_grounded_cache_key_includes_article_id(self, mocker):
+        """Same question text, different articles, must not share a cache
+        entry - caching on question text alone would leak article A's
+        cached answer to article B."""
+        from agents import responder as responder_module
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mocker.patch.object(responder_module, "redis_client", mock_redis)
+        mocker.patch.object(responder_module, "answer_grounded", return_value="an answer")
+        from agents.responder import responder_agent
+        state_a = make_state(user_input="tell me more", intent="grounded", active_article={"id": "article-a", "title": "t"})
+        state_b = make_state(user_input="tell me more", intent="grounded", active_article={"id": "article-b", "title": "t"})
+        responder_agent(state_a)
+        responder_agent(state_b)
+        cache_keys_used = [call.args[0] for call in mock_redis.get.call_args_list]
+        assert cache_keys_used[0] != cache_keys_used[1]


### PR DESCRIPTION
## Description
/dashboard was previously just a coming_soon.html stub. I built out the actual dashboard with CVE Watchlist, Top News, and a Feed section showing the article time, source, and summary. The feed can be filtered by Newest/Critical/Frequent and by source. Ask AI opens /chat with the selected article pre-loaded and answers using the article content, with a link back to the original article. Added the real Cohere integration in services/chat_llm.py for intent classification and article-grounded answers, reusing the existing approved setup.

I kept Ask AI single-turn for now. I tried tracking follow-up questions across turns with LLM-based judgment twice, but it was unreliable in live testing, so I dropped that approach. Ask AI now gives one direct answer grounded in the article, and follow-ups behave as normal chat. Also added a chitchat intent so messages like "hi" no longer fall through to the article dump fallback.

## Related Issue

Part of #232 (week 9), dashboard half. 

## Motivation and Context

/dashboard is the main home page and had been a stub since the week 9 scope was defined. The CVE/Severity/Affected System data was blocked on Aqib's #234, which is now merged. There’s real data available now: 12 articles have cve_id, 14 have severity, and 38 have affected_system, out of 1,291 total.

## How Has This Been Tested?
Tested live against the real data from #234, including real CVE IDs, HIGH/CRITICAL severities, and affected systems, as well as correct empty states. Found and fixed two issues during live testing: a logging import conflict caused by from flask import *, and UUID article IDs from psycopg breaking JSON/session storage. Also changed swallowed exceptions to log properly.

I also ran node --check on the Flask-rendered chat.html output. Filter parameters are whitelist-validated and source names are parameterized. The full suite is at 148 passing tests, with ~77 new ones covering model queries, routes, LLM classification/grounding, graph routing, and agent responses.

Also found a bug during testing, get_article_by_id() never selected content, so Ask AI's fallback to it was dead code. It was actually grounding on the short summary. Fixed the SELECT and flipped the priority to prefer content, with the same truncation summarizer.py uses. (Content here is the ~500-char ingestion excerpt, not a full scrape.) Verified live against a Krebs article where content and summary differ, and added 4 new tests for it.

## Screenshots (if appropriate):
This is the dashboard, main part of this PR
<img width="1512" height="864" alt="Screenshot 2026-08-14 at 1 40 01 PM" src="https://github.com/user-attachments/assets/018c122a-6ca0-46db-97f2-d7014c32001e" />
On clicking the "ask ai" button it re-routes to chat.
<img width="1512" height="867" alt="Screenshot 2026-08-14 at 1 43 31 PM" src="https://github.com/user-attachments/assets/7214e0dd-08a8-4245-9f18-3f831662bfe5" />
Earlier every message used to pull articles, now simple messages like this, replies normally.
<img width="1512" height="868" alt="Screenshot 2026-08-14 at 1 41 34 PM" src="https://github.com/user-attachments/assets/a2884f0f-e982-4937-9a0a-2b6c4a9b14a2" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
